### PR TITLE
Maven Support Added.

### DIFF
--- a/Asmsrc.xml
+++ b/Asmsrc.xml
@@ -1,0 +1,40 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  <id>src</id>
+  <formats>
+    <format>tar.gz</format>
+    </formats>
+		
+  <fileSets>
+    <fileSet>
+       <includes>
+			<include>README*</include>
+			<include>build.xml</include>
+			<include>CONTRIBUTORS</include>
+			<include>LICENSE</include>
+			<include>pom.xml</include>
+			<include>Asmsrc.xml</include>
+			<include>stdlib/**/*.java</include>
+			<include>stdlib/**/*.whiley</include>
+			<include>lib/wyrt.jar</include>
+			<include>lib/wyjc.jar</include>
+			<include>tests/**/*.whiley</include>
+			<include>tests/**/*.sysout</include>
+			<include>examples/**/*.whiley</include>
+			<include>bin/wyjc</include>
+			<include>bin/whiley</include>
+		
+		</includes>
+			
+    </fileSet>
+    <fileSet>
+      <!-- TODO: use expresssions instead: ${project.build.sourceDirectory}, etc -->
+          
+	  <includes>
+			<include>**/*.java</include>
+		</includes>
+    </fileSet>
+	</fileSets>
+	
+</assembly>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -54,3 +54,4 @@ Contributor Sign Offs
 ============================================================================
 
 Signed-off-by: David J. Pearce <david.pearce@ecs.vuw.ac.nz>
+Signed-off-by: Lee Trezise <Lee.Trezise@gmail.com>

--- a/build.xml
+++ b/build.xml
@@ -61,7 +61,7 @@
       <include name="bin/wyjc"/>
       <include name="bin/whiley"/>
     </fileset>
-    <fileset dir="." includes="LICENSE,README,build.xml"/>
+    <fileset dir="." includes="LICENSE,README,build.xml,pom.xml,CONTRIBUTORS,Asmsrc.xml"/>
     <fileset dir="." includes="lib/wyrt.jar,lib/wyjc.jar"/>
   </copy>
   <tar destfile="wdk-src-v${version}.tar" longfile="gnu">  
@@ -72,7 +72,7 @@
       <include name="wdk-v${version}/bin/wyjc"/>
       <include name="wdk-v${version}/bin/whiley"/>
     </tarfileset>
-    <tarfileset dir="." includes="wdk-v${version}/LICENSE,wdk-v${version}/README,wdk-v${version}/build.xml"/>
+    <tarfileset dir="." includes="wdk-v${version}/LICENSE,wdk-v${version}/README,wdk-v${version}/build.xml,wdk-v${version}/pom.xml,wdk-v${version}/Asmsrc.xml,wdk-v${version}/CONTRIBUTORS"/>
     <tarfileset dir="." includes="wdk-v${version}/lib/wyrt.jar,wdk-v${version}/lib/wyjc.jar"/>
   </tar>
   <gzip destfile="wdk-src-v${version}.tgz" src="wdk-src-v${version}.tar"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,192 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>whiley</groupId>
+	<artifactId>whiley</artifactId>
+	<packaging>jar</packaging>
+	<version>0.3.12</version>
+	<name>whiley-lang</name>
+	<description>Whiley: A Programming Language with Extended Static Checking </description>
+	<url>http://whiley.org</url>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+	<!-- Required For compiling the AntTask file. Looking to move away from this -->
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.ant</groupId>
+			<artifactId>ant</artifactId>
+			<version>1.8.2</version>
+		</dependency>
+	</dependencies>
+	<build>
+		
+		<plugins>
+			<!-- Compiler Plugin. Compiles all java files to target dir -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-compiler-plugin</artifactId>
+				<version>2.3.2</version>
+				<configuration>
+					<excludes>
+						<exclude>**/wyil/testing/**</exclude>
+						<exclude>**/wyjc/testing/**</exclude>
+						<exclude>**/*.whiley</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
+			<!-- Whiley file Compiler. Uses ANT task. Needs to be changed -->
+			<plugin>
+				<artifactId>maven-antrun-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>wyjc-compile</id>
+						<phase>compile</phase>
+						<goals>
+							<goal>run</goal>
+						</goals>
+						<configuration>
+							<tasks>
+								<taskdef name="wyjc" classname="wyjc.util.AntTask" classpath="target/classes/"/>
+								 <wyjc verbose="false" srcdir="stdlib" destdir="target/classes" includes="whiley/**/*.whiley"/>
+							</tasks>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- Jar Compiler -->
+			<plugin>
+				<artifactId>maven-jar-plugin</artifactId>
+				<version>2.3.2</version>
+				<executions>
+					<!-- Runtime Jar -->
+					<execution>
+						<id>wyrt</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier></classifier>
+							<includes>
+								<include>whiley/**</include>
+								<include>wyjc/runtime/**</include>
+							</includes>
+							<finalName>wyrt</finalName>
+							<appendAssemblyId>false</appendAssemblyId>
+							<outputDirectory>${basedir}/lib</outputDirectory>
+						</configuration>
+					</execution>
+					<!-- Distribution Source -->
+					<execution>
+						<id>distsrc</id>
+						<phase>package</phase>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+						<configuration>
+							<classifier></classifier>
+							<archive>
+								<manifest>
+									<mainClass>wyjc.Main</mainClass>
+									<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+								</manifest>
+							</archive>
+							<includes>
+								<include>whiley/**/*.class</include>
+								<include>wyil/**/*.class</include>
+								<include>wyc/**/* </include>
+								<include>wyjc/**/*.class</include>
+								<include>wyone/**/*.class</include>
+								<include>wyjvm/**/*.class</include>
+								<include>wyautl/**/*.class</include>
+							</includes>
+							<finalName>wyjc-v${project.version}</finalName>
+							<appendAssemblyId>false</appendAssemblyId>
+							<outputDirectory>${basedir}</outputDirectory>
+						</configuration>
+					</execution>
+					<!-- Whiley Compiler -->
+					<execution>
+						<id>wyjc</id>
+								<phase>package</phase>
+								<goals>
+									<goal>jar</goal>
+								</goals>
+									<configuration>
+									<classifier></classifier>
+									<archive>
+										<manifest>
+											<mainClass>wyjc.Main</mainClass>
+											<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+										</manifest>
+									</archive>
+									<includes>
+										<include>**/*.class</include>
+									</includes>
+									<finalName>wyjc</finalName>
+									<appendAssemblyId>false</appendAssemblyId>
+									<outputDirectory>${basedir}/lib</outputDirectory>
+								</configuration>
+							</execution>
+				</executions>
+			</plugin>
+			<!-- Sets Up the Source Directories -->
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>1.7</version>
+				<executions>
+					<execution>
+						<phase>generate-sources</phase>
+						<goals><goal>add-source</goal></goals>
+						<configuration>
+							<sources>
+								<source>src/</source>
+								<source>stdlib/</source>
+							</sources>
+							<includes> 
+								<include>*.java</include>
+								<include>*.whiley</include>
+							</includes>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		
+			<plugin>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>2.1</version>
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+						<configuration>
+							<descriptors>
+								<descriptor>Asmsrc.xml</descriptor>
+							</descriptors>
+							<finalName>wdk-src-v${project.version}</finalName>
+							<outputDirectory>${basedir}</outputDirectory>
+							<appendAssemblyId>false</appendAssemblyId>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+			<!-- Javadoc Generation -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.8</version>
+				<configuration>
+					<outputDirectory>${basedir}/docs</outputDirectory>
+					<maxMemory>512m</maxMemory>
+				</configuration>
+				
+				
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/src/wyjc/Main.java
+++ b/src/wyjc/Main.java
@@ -54,7 +54,11 @@ public class Main {
 		if(versionStr != null) {
 			String[] vb = versionStr.split("-");
 			String[] pts = vb[0].split("\\.");
-			BUILD_NUMBER = Integer.parseInt(vb[1]);
+			if(vb.length == 1) {
+				BUILD_NUMBER=0;
+			} else {
+			BUILD_NUMBER = Integer.parseInt(vb[1]); }
+			
 			MAJOR_VERSION = Integer.parseInt(pts[0]);
 			MINOR_VERSION = Integer.parseInt(pts[1]);
 			MINOR_REVISION = Integer.parseInt(pts[2]);


### PR DESCRIPTION
Javadoc plugin forces OOM exception. Use Ant javadoc generator for now.
Maven native support for generation of the archive files and java compilation.
Embedded ANT task used for Whiley build.
Updated build.xml to support clearing the temporary whiley files and class files from stdlib
Bug Fix for wyjc.Main. Now doesn't error if build number not supplied
Signed off on contribution
