### PR TITLE
Ensure Travis builds all projects

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,4 @@ jdk:
 
 #
 script:
-    ant test-all
+    ant build-all test-all


### PR DESCRIPTION
Change Travis to run Ant with both the `build-all` and `test-all` targets. Currently Travis just runs the `test-all` target, but that isn't enough because it only builds the artifacts needed to run the tests. Some modules will not be built at all. By including the `build-all` target we ensure that all artifacts are built.