### PR TITLE
Add support for Fail statement

### DIFF
--- a/modules/wyc/src/wyc/builder/CodeGenerator.java
+++ b/modules/wyc/src/wyc/builder/CodeGenerator.java
@@ -390,6 +390,8 @@ public final class CodeGenerator {
 				generate((Return) stmt, environment, codes, context);
 			} else if (stmt instanceof Debug) {
 				generate((Debug) stmt, environment, codes, context);
+			} else if (stmt instanceof Fail) {
+				generate((Fail) stmt, environment, codes, context);
 			} else if (stmt instanceof IfElse) {
 				generate((IfElse) stmt, environment, codes, context);
 			} else if (stmt instanceof Switch) {
@@ -807,6 +809,36 @@ public final class CodeGenerator {
 			AttributedCodeBlock codes, Context context) {
 		int operand = generate(s.expr, environment, codes, context);
 		codes.add(Codes.Debug(operand), attributes(s));
+	}
+
+	/**
+	 * Translate a fail statement into WyIL bytecodes.
+	 *
+	 * <pre>
+	 * fail
+	 * </pre>
+	 *
+	 * A fail statement is always translated into a WyIL fail bytecode:
+	 *
+	 * <pre>
+	 * fail
+	 * </pre>
+	 *
+	 * @param stmt
+	 *            --- Statement to be translated.
+	 * @param environment
+	 *            --- Mapping from variable names to block registers.
+	 * @param codes
+	 *            --- Code block into which this statement is to be translated.
+	 * @param context
+	 *            --- Enclosing context of this statement (i.e. type, constant,
+	 *            function or method declaration). The context is used to aid
+	 *            with error reporting as it determines the enclosing file.
+	 * @return
+	 */
+	private void generate(Stmt.Fail s, Environment environment,
+			AttributedCodeBlock codes, Context context) {
+		codes.add(Codes.Fail(), attributes(s));
 	}
 
 	/**
@@ -2274,8 +2306,8 @@ public final class CodeGenerator {
 			WhileyFile.Context context) {
 		if (stmt instanceof Assign || stmt instanceof Assert
 				|| stmt instanceof Assume || stmt instanceof Return
-				|| stmt instanceof Debug || stmt instanceof Break
-				|| stmt instanceof Continue
+				|| stmt instanceof Debug || stmt instanceof Fail
+				|| stmt instanceof Break || stmt instanceof Continue
 				|| stmt instanceof Expr.MethodCall
 				|| stmt instanceof Expr.IndirectMethodCall
 				|| stmt instanceof Expr.FunctionCall

--- a/modules/wyc/src/wyc/builder/FlowTypeChecker.java
+++ b/modules/wyc/src/wyc/builder/FlowTypeChecker.java
@@ -351,7 +351,10 @@ public class FlowTypeChecker {
 	 * @return
 	 */
 	private Environment propagate(Stmt stmt, Environment environment) {
-
+		if (environment == BOTTOM) {
+			syntaxError(errorMessage(UNREACHABLE_CODE), filename, stmt);
+			return null; // dead code
+		}
 		try {
 			if (stmt instanceof Stmt.VariableDeclaration) {
 				return propagate((Stmt.VariableDeclaration) stmt, environment);
@@ -375,6 +378,8 @@ public class FlowTypeChecker {
 				return propagate((Stmt.Assert) stmt, environment);
 			} else if (stmt instanceof Stmt.Assume) {
 				return propagate((Stmt.Assume) stmt, environment);
+			} else if (stmt instanceof Stmt.Fail) {
+				return propagate((Stmt.Fail) stmt, environment);
 			} else if (stmt instanceof Stmt.Debug) {
 				return propagate((Stmt.Debug) stmt, environment);
 			} else if (stmt instanceof Stmt.Skip) {
@@ -426,6 +431,21 @@ public class FlowTypeChecker {
 		stmt.expr = propagate(stmt.expr, environment, current);
 		checkIsSubtype(Type.T_BOOL, stmt.expr);
 		return environment;
+	}
+
+	/**
+	 * Type check a fail statement. The environment after a fail statement is
+	 * "bottom" because that represents an unreachable program point.
+	 *
+	 * @param stmt
+	 *            Statement to type check
+	 * @param environment
+	 *            Determines the type of all variables immediately going into
+	 *            this block
+	 * @return
+	 */
+	private Environment propagate(Stmt.Fail stmt, Environment environment) {
+		return BOTTOM;
 	}
 
 	/**

--- a/modules/wyc/src/wyc/io/WhileyFileLexer.java
+++ b/modules/wyc/src/wyc/io/WhileyFileLexer.java
@@ -535,6 +535,7 @@ public class WhileyFileLexer {
 			put("do", Token.Kind.Do);
 			put("else", Token.Kind.Else);
 			put("ensures", Token.Kind.Ensures);
+			put("fail", Token.Kind.Fail);
 			put("for", Token.Kind.For);
 			put("if", Token.Kind.If);
 			put("new", Token.Kind.New);
@@ -694,6 +695,11 @@ public class WhileyFileLexer {
 				}
 			},
 			For {
+				public String toString() {
+					return "for";
+				}
+			},
+			Fail {
 				public String toString() {
 					return "for";
 				}

--- a/modules/wyc/src/wyc/io/WhileyFileParser.java
+++ b/modules/wyc/src/wyc/io/WhileyFileParser.java
@@ -630,6 +630,8 @@ public class WhileyFileParser {
 			return parseDoWhileStatement(wf, environment, indent);
 		case Debug:
 			return parseDebugStatement(wf, environment);
+		case Fail:
+			return parseFailStatement(environment);
 		case If:
 			return parseIfStatement(wf, environment, indent);
 		case Return:
@@ -820,7 +822,7 @@ public class WhileyFileParser {
 	 *            This is necessary to identify local variables within
 	 *            expressions used in this statement.
 	 *
-	 * @see wyc.lang.Stmt.Debug
+	 * @see wyc.lang.Stmt.Assert
 	 * @return
 	 */
 	private Stmt.Assert parseAssertStatement(WhileyFile wf,
@@ -854,7 +856,7 @@ public class WhileyFileParser {
 	 *            This is necessary to identify local variables within
 	 *            expressions used in this statement.
 	 *
-	 * @see wyc.lang.Stmt.Debug
+	 * @see wyc.lang.Stmt.Assume
 	 * @return
 	 */
 	private Stmt.Assume parseAssumeStatement(WhileyFile wf,
@@ -884,7 +886,7 @@ public class WhileyFileParser {
 	 *            This is necessary to identify local variables within
 	 *            expressions used in this statement.
 	 *
-	 * @see wyc.lang.Stmt.Debug
+	 * @see wyc.lang.Stmt.Break
 	 * @return
 	 */
 	private Stmt.Break parseBreakStatement(HashSet<String> environment) {
@@ -909,7 +911,7 @@ public class WhileyFileParser {
 	 *            This is necessary to identify local variables within
 	 *            expressions used in this statement.
 	 *
-	 * @see wyc.lang.Stmt.Debug
+	 * @see wyc.lang.Stmt.Continue
 	 * @return
 	 */
 	private Stmt.Continue parseContinueStatement(HashSet<String> environment) {
@@ -1000,6 +1002,30 @@ public class WhileyFileParser {
 		matchEndLine();
 		return new Stmt.DoWhile(condition, invariants, blk, sourceAttr(start,
 				end - 1));
+	}
+
+	/**
+	 * Parse a fail statement, which is of the form:
+	 *
+	 * <pre>
+	 * FailStmt ::= "fail"
+	 * </pre>
+	 *
+	 * @param environment
+	 *            The set of declared variables visible in the enclosing scope.
+	 *            The environment is not used by the fail statement.
+	 *
+	 * @see wyc.lang.Stmt.Fail
+	 * @return
+	 */
+	private Stmt.Fail parseFailStatement(HashSet<String> environment) {
+		int start = index;
+		// Match the fail keyword
+		match(Fail);
+		int end = index;
+		matchEndLine();
+		// Done.
+		return new Stmt.Fail(sourceAttr(start, end - 1));
 	}
 
 	/**
@@ -1119,7 +1145,7 @@ public class WhileyFileParser {
 	 *            This is necessary to identify local variables within
 	 *            expressions used in this statement.
 	 *
-	 * @see wyc.lang.Stmt.Debug
+	 * @see wyc.lang.Stmt.Skip
 	 * @return
 	 */
 	private Stmt.Skip parseSkipStatement(HashSet<String> environment) {

--- a/modules/wyc/src/wyc/lang/Stmt.java
+++ b/modules/wyc/src/wyc/lang/Stmt.java
@@ -408,6 +408,15 @@ public interface Stmt extends SyntacticElement {
 	}
 
 	/**
+	 * Represents a fail statement.
+	 */
+	public static final class Fail extends SyntacticElement.Impl implements Stmt {
+		public Fail(Attribute... attributes) {
+			super(attributes);
+		}
+	}
+
+	/**
 	 * Represents a classical if-else statement, which is has the form:
 	 *
 	 * <pre>

--- a/tests/invalid/Continue_Invalid_2.sysout
+++ b/tests/invalid/Continue_Invalid_2.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Continue_Invalid_2.whiley:4: unreachable code encountered (i.e. execution can never reach this statement)
+        x = x + 1
+        ^^^^^^^^^

--- a/tests/invalid/Continue_Invalid_2.whiley
+++ b/tests/invalid/Continue_Invalid_2.whiley
@@ -1,0 +1,5 @@
+function f(int x) -> int:
+    while x > 0:
+        continue
+        x = x + 1
+    return 0

--- a/tests/invalid/Fail_Invalid_1.sysout
+++ b/tests/invalid/Fail_Invalid_1.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Fail_Invalid_1.whiley:11: assertion failed
+        fail
+        ^^^^

--- a/tests/invalid/Fail_Invalid_1.whiley
+++ b/tests/invalid/Fail_Invalid_1.whiley
@@ -1,0 +1,11 @@
+type nat1 is (int x) where x >= 1
+type neg is (int x) where x < 0
+
+function f(int|null x) -> bool|null:
+    //
+    if x is nat1:
+        return true
+    else if x is neg:
+        return false
+    else:
+        fail

--- a/tests/invalid/Fail_Invalid_2.sysout
+++ b/tests/invalid/Fail_Invalid_2.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Fail_Invalid_2.whiley:3: unreachable code encountered (i.e. execution can never reach this statement)
+  return x + 1
+  ^^^^^^^^^^^^

--- a/tests/invalid/Fail_Invalid_2.whiley
+++ b/tests/invalid/Fail_Invalid_2.whiley
@@ -1,0 +1,3 @@
+function incr(int x) -> int:
+  fail
+  return x + 1

--- a/tests/invalid/Return_Invalid_12.sysout
+++ b/tests/invalid/Return_Invalid_12.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Return_Invalid_12.whiley:3: unreachable code encountered (i.e. execution can never reach this statement)
+  return
+  ^^^^^^

--- a/tests/invalid/Return_Invalid_12.whiley
+++ b/tests/invalid/Return_Invalid_12.whiley
@@ -1,0 +1,3 @@
+function f():
+  return
+  return

--- a/tests/invalid/Switch_Invalid_2.whiley
+++ b/tests/invalid/Switch_Invalid_2.whiley
@@ -4,4 +4,3 @@ function f(int x) -> int:
             return 0
         case 1:
             return -1
-    return 10

--- a/tests/invalid/Switch_Invalid_3.whiley
+++ b/tests/invalid/Switch_Invalid_3.whiley
@@ -4,4 +4,3 @@ function f(int x) -> int:
             return 0
         default:
             return 1
-    return 10

--- a/tests/invalid/Switch_Invalid_4.whiley
+++ b/tests/invalid/Switch_Invalid_4.whiley
@@ -6,4 +6,3 @@ function f(int x) -> int:
             return 1
         default:
             return 0
-    return 10

--- a/tests/invalid/While_Invalid_14.sysout
+++ b/tests/invalid/While_Invalid_14.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/While_Invalid_14.whiley:11: unreachable code encountered (i.e. execution can never reach this statement)
+            break
+            ^^^^^

--- a/tests/invalid/While_Invalid_14.whiley
+++ b/tests/invalid/While_Invalid_14.whiley
@@ -1,0 +1,14 @@
+type nat is (int x) where x > 0
+
+function f(int v) -> (int r)
+ensures r >= 0:
+    //
+    int i = 0
+    while i < 100 where i >= 0:
+        i = i - 1
+        if i == v:
+            break
+            break
+        i = i + 2
+    //
+    return i

--- a/tests/valid/Fail_Valid_1.whiley
+++ b/tests/valid/Fail_Valid_1.whiley
@@ -1,0 +1,16 @@
+type nat is (int x) where x >= 0
+type neg is (int x) where x < 0
+
+function f(int|null x) -> bool|null:
+    //
+    if x is nat:
+        return true
+    else if x is neg:
+        return false
+    else:
+        fail
+
+public export method test() :
+    assume f(-1) == false
+    assume f(0) == true
+    assume f(1) == true

--- a/tests/valid/Fail_Valid_2.whiley
+++ b/tests/valid/Fail_Valid_2.whiley
@@ -1,0 +1,11 @@
+type nat is (int x) where x >= 0
+
+function zero() -> int:
+    int x = 0
+    if x == 0:
+        return x
+    else:
+        fail
+
+public export method test() :
+    assume zero() == 0


### PR DESCRIPTION
This required adding the fail statement as an extra case in the lexing, parsing, code generation and type checking code. The type checker now checks the propagated environment and reports code as unreachable if its environment is bottom.