### PR TITLE
Increase precedence of unary expressions

### DIFF
--- a/modules/wyc/src/wyc/io/WhileyFileParser.java
+++ b/modules/wyc/src/wyc/io/WhileyFileParser.java
@@ -2525,7 +2525,7 @@ public class WhileyFileParser {
 			// bracketed type.
 			if (tryAndMatch(true, RightBrace) != null) {
 				// Ok, finally, we are sure that it is definitely a cast.
-				Expr e = parseExpression(wf, environment, terminated);
+				Expr e = parseTermExpression(wf, environment, terminated);
 				return new Expr.Cast(t, e, sourceAttr(start, index - 1));
 			}
 		}
@@ -2572,12 +2572,12 @@ public class WhileyFileParser {
 				case VerticalBar:
 				case Shreak:
 				case Identifier: {
-					// Ok, this must be cast so back tract and reparse
+					// Ok, this must be cast so back track and reparse
 					// expression as a type.
 					index = start; // backtrack
 					SyntacticType type = parseType();
 					// Now, parse cast expression
-					e = parseExpression(wf, environment, terminated);
+					e = parseTermExpression(wf, environment, terminated);
 					return new Expr.Cast(type, e, sourceAttr(start, index - 1));
 				}
 				default:
@@ -2831,7 +2831,7 @@ public class WhileyFileParser {
 			boolean terminated) {
 		int start = index;
 		match(New);
-		Expr e = parseExpression(wf, environment, terminated);
+		Expr e = parseTermExpression(wf, environment, terminated);
 		return new Expr.New(e, sourceAttr(start, index - 1));
 	}
 
@@ -2914,7 +2914,7 @@ public class WhileyFileParser {
 			HashSet<String> environment, boolean terminated) {
 		int start = index;
 		match(Minus);
-		Expr e = parseAccessExpression(wf, environment, terminated);
+		Expr e = parseTermExpression(wf, environment, terminated);
 		return new Expr.UnOp(Expr.UOp.NEG, e, sourceAttr(start, index - 1));
 	}
 
@@ -3065,7 +3065,7 @@ public class WhileyFileParser {
 		// Note: cannot parse unit expression here, because that messes up the
 		// precedence. For example, !result ==> other should be parsed as
 		// (!result) ==> other, not !(result ==> other).
-		Expr expression = parseConditionExpression(wf, environment, terminated);
+		Expr expression = parseTermExpression(wf, environment, terminated);
 		return new Expr.UnOp(Expr.UOp.NOT, expression, sourceAttr(start,
 				index - 1));
 	}
@@ -3093,7 +3093,7 @@ public class WhileyFileParser {
 			HashSet<String> environment, boolean terminated) {
 		int start = index;
 		match(Star);
-		Expr expression = parseExpression(wf, environment, terminated);
+		Expr expression = parseTermExpression(wf, environment, terminated);
 		return new Expr.Dereference(expression, sourceAttr(start, index - 1));
 	}
 
@@ -3300,7 +3300,7 @@ public class WhileyFileParser {
 			HashSet<String> environment, boolean terminated) {
 		int start = index;
 		match(Tilde);
-		Expr expression = parseExpression(wf, environment, terminated);
+		Expr expression = parseTermExpression(wf, environment, terminated);
 		return new Expr.UnOp(Expr.UOp.INVERT, expression, sourceAttr(start,
 				index - 1));
 	}

--- a/modules/wyc/src/wyc/lang/Expr.java
+++ b/modules/wyc/src/wyc/lang/Expr.java
@@ -800,6 +800,10 @@ public interface Expr extends SyntacticElement {
 		public Nominal.Reference result() {
 			return type;
 		}
+
+		public String toString() {
+			return "(new " + expr.toString() + ")";
+		}
 	}
 
 	public enum BOp {

--- a/modules/wyrt/src/whiley/lang/Int.whiley
+++ b/modules/wyrt/src/whiley/lang/Int.whiley
@@ -188,7 +188,7 @@ public function parse(string input) -> int|null:
     while i < |input|:
         char c = input[i]
         r = r * 10
-        if !ASCII.isDigit(c):
+        if !(ASCII.isDigit(c)):
             return null
         r = r + ((int) c - '0')
         i = i + 1

--- a/tests/invalid/BitwiseComplement_Invalid_1.sysout
+++ b/tests/invalid/BitwiseComplement_Invalid_1.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/BitwiseComplement_Invalid_1.whiley:5: expected type byte, found {byte b}
+    assume ~r.b == 11111111b
+            ^

--- a/tests/invalid/BitwiseComplement_Invalid_1.whiley
+++ b/tests/invalid/BitwiseComplement_Invalid_1.whiley
@@ -1,0 +1,5 @@
+type byterec is {byte b}
+
+public export method test():
+    byterec r = {b: 00000000b}
+    assume ~r.b == 11111111b

--- a/tests/invalid/Cast_Invalid_1.sysout
+++ b/tests/invalid/Cast_Invalid_1.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Cast_Invalid_1.whiley:5: expected type bool, found {bool b}
+    assume (bool) r.b
+           ^^^^^^^^

--- a/tests/invalid/Cast_Invalid_1.whiley
+++ b/tests/invalid/Cast_Invalid_1.whiley
@@ -1,0 +1,5 @@
+type boolrec is {bool b}
+
+public export method test():
+    boolrec r = {b: true}
+    assume (bool) r.b

--- a/tests/invalid/LogicalNot_Invalid_1.sysout
+++ b/tests/invalid/LogicalNot_Invalid_1.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/LogicalNot_Invalid_1.whiley:2: expected type bool, found int
+    assume !1 < 1
+            ^

--- a/tests/invalid/LogicalNot_Invalid_1.whiley
+++ b/tests/invalid/LogicalNot_Invalid_1.whiley
@@ -1,0 +1,2 @@
+public export method test():
+    assume !1 < 1

--- a/tests/invalid/LogicalNot_Invalid_2.sysout
+++ b/tests/invalid/LogicalNot_Invalid_2.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/LogicalNot_Invalid_2.whiley:2: expected type bool, found bool[]
+    assume ![false][0]
+            ^^^^^^^

--- a/tests/invalid/LogicalNot_Invalid_2.whiley
+++ b/tests/invalid/LogicalNot_Invalid_2.whiley
@@ -1,0 +1,2 @@
+public export method test():
+    assume ![false][0]

--- a/tests/invalid/Negation_Invalid_1.sysout
+++ b/tests/invalid/Negation_Invalid_1.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Negation_Invalid_1.whiley:2: expecting int, found int[]
+    assume -[-1][0] == 1
+            ^^^^

--- a/tests/invalid/Negation_Invalid_1.whiley
+++ b/tests/invalid/Negation_Invalid_1.whiley
@@ -1,0 +1,2 @@
+public export method test():
+    assume -[-1][0] == 1

--- a/tests/invalid/Reference_Invalid_1.sysout
+++ b/tests/invalid/Reference_Invalid_1.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Reference_Invalid_1.whiley:3: invalid reference expression
+    assume *x[0] == 1
+            ^

--- a/tests/invalid/Reference_Invalid_1.whiley
+++ b/tests/invalid/Reference_Invalid_1.whiley
@@ -1,0 +1,3 @@
+public export method test():
+    (&int)[] x = [new 1]
+    assume *x[0] == 1

--- a/tests/invalid/Reference_Invalid_2.sysout
+++ b/tests/invalid/Reference_Invalid_2.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Reference_Invalid_2.whiley:0: invalid array expression
+
+^

--- a/tests/invalid/Reference_Invalid_2.whiley
+++ b/tests/invalid/Reference_Invalid_2.whiley
@@ -1,0 +1,2 @@
+public export method test():
+    &int x = new [1][0]

--- a/tests/valid/BitwiseComplement_Valid_1.whiley
+++ b/tests/valid/BitwiseComplement_Valid_1.whiley
@@ -1,0 +1,2 @@
+public export method test():
+    assume ~00000000b == 11111111b

--- a/tests/valid/BitwiseComplement_Valid_2.whiley
+++ b/tests/valid/BitwiseComplement_Valid_2.whiley
@@ -1,0 +1,5 @@
+type byterec is {byte b}
+
+public export method test():
+    byterec r = {b: 00000000b}
+    assume ~(r.b) == 11111111b

--- a/tests/valid/Cast_Valid_6.whiley
+++ b/tests/valid/Cast_Valid_6.whiley
@@ -1,0 +1,2 @@
+public export method test():
+    assume (int) 1 == 1

--- a/tests/valid/Cast_Valid_7.whiley
+++ b/tests/valid/Cast_Valid_7.whiley
@@ -1,0 +1,5 @@
+type boolrec is {bool b}
+
+public export method test():
+    boolrec r = {b: true}
+    assume (boolrec) r.b

--- a/tests/valid/Lambda_Valid_4.whiley
+++ b/tests/valid/Lambda_Valid_4.whiley
@@ -69,7 +69,7 @@ method read(string s) -> byte[]:
     byte[] bytes = [0b;0]
     InputStream bis = BufferInputStream(toBytes(s))
     //
-    while !bis.eof():
+    while !(bis.eof()):
         bytes = bis.read(3)
     //
     return bytes

--- a/tests/valid/LogicalNot_Valid_1.whiley
+++ b/tests/valid/LogicalNot_Valid_1.whiley
@@ -1,0 +1,2 @@
+public export method test():
+    assume !true ==> true

--- a/tests/valid/LogicalNot_Valid_2.whiley
+++ b/tests/valid/LogicalNot_Valid_2.whiley
@@ -1,0 +1,3 @@
+public export method test():
+    bool[] a = [false]
+    assume !(a[0])

--- a/tests/valid/Negation_Valid_10.whiley
+++ b/tests/valid/Negation_Valid_10.whiley
@@ -1,0 +1,2 @@
+public export method test():
+    assume -*new 1 == ---1

--- a/tests/valid/Negation_Valid_11.whiley
+++ b/tests/valid/Negation_Valid_11.whiley
@@ -1,0 +1,10 @@
+type intrec is {int i}
+
+public export method test():
+    intrec r = {i: 1}
+    assume -(r.i) == -1
+    assume -1 == -(r.i)
+    int[] a = [-1]
+    assume -1 == a[0]
+    assume a[0] == -1
+    assume -([-1][0]) == 1

--- a/tests/valid/OpenRecord_Valid_4.whiley
+++ b/tests/valid/OpenRecord_Valid_4.whiley
@@ -9,7 +9,7 @@ function getField(OpenRecord r) -> int:
         if r is {int y, int x}:
             return r.x + r.y
         else:
-            return -r.x
+            return -(r.x)
 
 public export method test() :
     OpenRecord r = {x: 1}

--- a/tests/valid/Reference_Valid_10.whiley
+++ b/tests/valid/Reference_Valid_10.whiley
@@ -1,0 +1,3 @@
+public export method test():
+    &int x = new ([1][0])
+    assume *x == 1

--- a/tests/valid/Reference_Valid_9.whiley
+++ b/tests/valid/Reference_Valid_9.whiley
@@ -1,0 +1,3 @@
+public export method test():
+    &int x = new 1
+    assume *x == 1

--- a/tests/valid/While_Valid_11.whiley
+++ b/tests/valid/While_Valid_11.whiley
@@ -8,7 +8,7 @@ function extract(int[] ls) -> nat[]:
         where all { j in 0..|r| | r[j] >= 0 }:
         //
         if ls[i] < 0:
-            r[i] = -ls[i]
+            r[i] = -(ls[i])
         else:
             r[i] = ls[i]
         i = i + 1

--- a/tests/valid/While_Valid_37.whiley
+++ b/tests/valid/While_Valid_37.whiley
@@ -6,7 +6,7 @@ requires |bits| == 8
 // Postcondition: return a byte as well
 ensures |r| == 8
 // Postcondition: every bit must be inverted
-ensures all { i in 0 .. 8 | r[i] == !bits[i] }:
+ensures all { i in 0 .. 8 | r[i] == !(bits[i]) }:
     //
     int i = 0
     bool[] ret = bits
@@ -15,9 +15,9 @@ ensures all { i in 0 .. 8 | r[i] == !bits[i] }:
     // i is non-negative, and size of bits unchanged
     where i >= 0 && |ret| == |bits| && i <= |bits|
     // Every bit upto i is inverted now
-    where all { j in 0 .. i | ret[j] == !bits[j] }:
+    where all { j in 0 .. i | ret[j] == !(bits[j]) }:
         //
-        ret[i] = !bits[i]
+        ret[i] = !(bits[i])
         i = i + 1
     //
     return ret


### PR DESCRIPTION
Unary expressions have been changed to have the highest precedence, bringing them in line with the specification. The following kinds of unary expressions were updated: logical not (`!`), bitwise complement (`~`), negation (`-`), casts, new and dereference (`*`).

Fixes #491.
