### PR TITLE
Allow filtering of tests run from command line

### DIFF
--- a/modules/wyc/build.xml
+++ b/modules/wyc/build.xml
@@ -41,12 +41,18 @@
     </javac>
   </target>
 
+  <!-- Set the default value of this property. Since Ant properties are immutable
+       if the value has already been set by the user with -Dtest.name.contains=...
+       this will not override that value. -->
+  <property name="test.name.contains" value=""/>
+
   <target name="test" depends="test-compile-wyc">
     <junit fork="true" dir="${basedir}" failureProperty="tests.failed" printsummary="yes" outputtoformatters="true">
       <classpath>
         <pathelement path="src:../wyil/src:../wybs/src/:../wycs/src:../../${WYRL_JAR}"/>
         <path refid="junit.classpath"/>
       </classpath>
+      <sysproperty key="test.name.contains" value="${test.name.contains}"/>
       <batchtest>
         <fileset dir="src" includes="wyc/testing/*Tests.java"/>
       </batchtest>

--- a/modules/wyc/src/wyc/testing/AllInvalidTests.java
+++ b/modules/wyc/src/wyc/testing/AllInvalidTests.java
@@ -225,23 +225,7 @@ public class AllInvalidTests {
 	// Here we enumerate all available test cases.
 	@Parameters(name = "{0}")
 	public static Collection<Object[]> data() {
-		List<String> testNames = new ArrayList<String>();
-		for (File f : new File(WHILEY_SRC_DIR).listFiles()) {
-			if (f.isFile()) {
-				String name = f.getName();
-				if (name.endsWith(".whiley")) {
-					// Get rid of ".whiley" extension
-					String testName = name.substring(0, name.length() - 7);
-					testNames.add(testName);
-				}
-			}
-		}
-		Collections.sort(testNames);
-		ArrayList<Object[]> result = new ArrayList<Object[]>(testNames.size());
-		for (String testName : testNames) {
-			result.add(new Object[] { testName });
-		}
-		return result;
+		return TestUtils.findTestNames(WHILEY_SRC_DIR);
 	}
 
 	// Skip ignored tests

--- a/modules/wyc/src/wyc/testing/AllValidTests.java
+++ b/modules/wyc/src/wyc/testing/AllValidTests.java
@@ -199,23 +199,7 @@ public class AllValidTests {
 	// Here we enumerate all available test cases.
 	@Parameters(name = "{0}")
 	public static Collection<Object[]> data() {
-		List<String> testNames = new ArrayList<String>();
-		for (File f : new File(WHILEY_SRC_DIR).listFiles()) {
-			if (f.isFile()) {
-				String name = f.getName();
-				if (name.endsWith(".whiley")) {
-					// Get rid of ".whiley" extension
-					String testName = name.substring(0, name.length() - 7);
-					testNames.add(testName);
-				}
-			}
-		}
-		Collections.sort(testNames);
-		ArrayList<Object[]> result = new ArrayList<Object[]>(testNames.size());
-		for (String testName : testNames) {
-			result.add(new Object[] { testName });
-		}
-		return result;
+		return TestUtils.findTestNames(WHILEY_SRC_DIR);
 	}
 
 	// Skip ignored tests

--- a/modules/wyc/src/wyc/testing/AllValidVerificationTests.java
+++ b/modules/wyc/src/wyc/testing/AllValidVerificationTests.java
@@ -284,23 +284,7 @@ public class AllValidVerificationTests {
 	// Here we enumerate all available test cases.
 	@Parameters(name = "{0}")
 	public static Collection<Object[]> data() {
-		List<String> testNames = new ArrayList<String>();
-		for (File f : new File(WHILEY_SRC_DIR).listFiles()) {
-			if (f.isFile()) {
-				String name = f.getName();
-				if (name.endsWith(".whiley")) {
-					// Get rid of ".whiley" extension
-					String testName = name.substring(0, name.length() - 7);
-					testNames.add(testName);
-				}
-			}
-		}
-		Collections.sort(testNames);
-		ArrayList<Object[]> result = new ArrayList<Object[]>(testNames.size());
-		for (String testName : testNames) {
-			result.add(new Object[] { testName });
-		}
-		return result;
+		return TestUtils.findTestNames(WHILEY_SRC_DIR);
 	}
 
 	// Skip ignored tests

--- a/modules/wyc/src/wyc/testing/TestUtils.java
+++ b/modules/wyc/src/wyc/testing/TestUtils.java
@@ -4,7 +4,9 @@ import static org.junit.Assert.fail;
 
 import java.io.*;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 
 import wybs.lang.Build;
 import wybs.util.StdProject;
@@ -30,6 +32,46 @@ import wyil.util.Interpreter;
  *
  */
 public class TestUtils {
+
+	/**
+	 * Scan a directory to get the names of all the whiley source files
+	 * in that directory. The list of file names can be used as input
+	 * parameters to a JUnit test.
+	 *
+	 * If the system property <code>test.name.contains</code> is set,
+	 * then the list of files returned will be filtered. Only file
+	 * names that contain the property will be returned. This makes it
+	 * possible to run a subset of tests when testing interactively
+	 * from the command line.
+	 *
+	 * @param srcDir The path of the directory to scan.
+	 */
+	public static Collection<Object[]> findTestNames(String srcDir) {
+		final String suffix = ".whiley";
+		String containsFilter = System.getProperty("test.name.contains");
+
+		ArrayList<Object[]> testcases = new ArrayList<Object[]>();
+		for (File f : new File(srcDir).listFiles()) {
+			// Check it's a file
+			if (!f.isFile()) continue;
+			String name = f.getName();
+			// Check it's a whiley source file
+			if (!name.endsWith(suffix)) continue;
+			// Get rid of ".whiley" extension
+			String testName = name.substring(0, name.length() - suffix.length());
+			// If there's a filter, check the name matches
+			if (containsFilter != null && !testName.contains(containsFilter)) continue;
+			testcases.add(new Object[] { testName });
+		}
+		// Sort the result by filename
+		Collections.sort(testcases, new Comparator<Object[]>() {
+				@Override
+				public int compare(Object[] o1, Object[] o2) {
+					return ((String) o1[0]).compareTo((String) o2[0]);
+				}
+		});
+		return testcases;
+	}
 
 	/**
 	 * Run the Whiley Compiler with the given list of arguments.


### PR DESCRIPTION
When running tests from the command line it is now possible to supply a system property that filters the tests to run. This makes it easier to interactively test the Whiley compiler from the command line.