### PR TITLE
Finally(?) resolve issues with travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ jdk:
 
 #
 script:
-    ant test-all
+    - touch running_on_travis
+    - ant test-all

--- a/modules/wyc/build.xml
+++ b/modules/wyc/build.xml
@@ -47,7 +47,7 @@
   <property name="test.name.contains" value=""/>
 
   <target name="test" depends="test-compile-wyc">
-    <junit fork="true" dir="${basedir}" failureProperty="tests.failed" printsummary="yes" outputtoformatters="true">
+    <junit fork="true" dir="${basedir}" failureProperty="tests.failed" printsummary="yes" showoutput="yes" outputtoformatters="no">
       <classpath>
         <pathelement path="src:../wyil/src:../wybs/src/:../wycs/src:../../${WYRL_JAR}"/>
         <path refid="junit.classpath"/>

--- a/modules/wyc/src/wyc/testing/AllInvalidTests.java
+++ b/modules/wyc/src/wyc/testing/AllInvalidTests.java
@@ -243,6 +243,9 @@ public class AllInvalidTests {
 
 	@Test
 	public void invalid() throws IOException {
+		if (new File("../../running_on_travis").exists()) {
+			System.out.println(".");
+		}
 		runTest(this.testName);
 	}
 }

--- a/modules/wyc/src/wyc/testing/AllValidTests.java
+++ b/modules/wyc/src/wyc/testing/AllValidTests.java
@@ -211,6 +211,9 @@ public class AllValidTests {
 
 	@Test
 	public void valid() throws IOException {
+		if (new File("../../running_on_travis").exists()) {
+			System.out.println(".");
+		}
 		runTest(this.testName);
 	}
 }

--- a/modules/wyc/src/wyc/testing/AllValidVerificationTests.java
+++ b/modules/wyc/src/wyc/testing/AllValidVerificationTests.java
@@ -296,6 +296,9 @@ public class AllValidVerificationTests {
 
 	@Test
 	public void validVerification() throws IOException {
+		if (new File("../../running_on_travis").exists()) {
+			System.out.println(".");
+		}
 		runTest(this.testName);
 	}
 }


### PR DESCRIPTION
Ant's formaters for JUnit runt the whole suite, collecting all stdout and then print the summary + stdout. Especially in the AllValidVerificationTests suite the run takes very long and during that time there is no output to standard output.

Travis doesn't like that at all and rewards us with a terminated build: _"No output has been received in the last 10 minutes, this potentially indicates a stalled build or something wrong with the build itself."_

This change here modifies the test process:
* We tell Ant to directly print any output instead of waiting for the summary (`showoutput="yes"`)
* As we don't need the output twice, we tell Ant to not print it with formatters (`outputtoformatters="no"`)
* Ant's list of executed tests does not show up until all tests are completed. Therefore we need to generate some output ourselves. I just print a dot for every executed test. As it is very spamish, I do a trick to avoid it when running locally: Before starting the build on travis we create a file called `running_on_travis`. Only if that file exists we send the spam dots to stdout.