### PR TITLE
Introduce Lifetimes

### DIFF
--- a/modules/wyc/src/wyc/builder/CodeGenerator.java
+++ b/modules/wyc/src/wyc/builder/CodeGenerator.java
@@ -312,6 +312,8 @@ public final class CodeGenerator {
 				generate((Break) stmt, scope);
 			} else if (stmt instanceof Continue) {
 				generate((Continue) stmt, scope);
+			} else if (stmt instanceof NamedBlock) {
+				generate((NamedBlock) stmt, scope);
 			} else if (stmt instanceof While) {
 				generate((While) stmt, scope);
 			} else if (stmt instanceof DoWhile) {
@@ -974,6 +976,15 @@ public final class CodeGenerator {
 	}
 	
 	
+	/**
+	 * Translate a named block into WyIL bytecodes.
+	 */
+	private void generate(Stmt.NamedBlock s, EnclosingScope scope) {
+		for (Stmt st : s.body) {
+			generate(st, scope);
+		}
+	}
+
 	/**
 	 * Translate a while loop into WyIL bytecodes. Consider the following use of
 	 * a while statement:
@@ -1675,7 +1686,8 @@ public final class CodeGenerator {
 		if(lambdaType instanceof Nominal.Function) {
 			return Type.Function(rawLambdaType.returns(),rawParamTypes);
 		} else {
-			return Type.Method(rawLambdaType.returns(),rawParamTypes);
+			return Type.Method(rawLambdaType.returns(),rawLambdaType.contextLifetimes(),
+					rawLambdaType.lifetimeParams(),rawParamTypes);
 		}
 	}
 	

--- a/modules/wyc/src/wyc/io/WhileyFileLexer.java
+++ b/modules/wyc/src/wyc/io/WhileyFileLexer.java
@@ -563,6 +563,8 @@ public class WhileyFileLexer {
 			put("export", Token.Kind.Export);
 			put("method", Token.Kind.Method);
 			put("package", Token.Kind.Package);
+			// lifetimes
+			put("this", Token.Kind.This);
 		}
 	};
 
@@ -627,6 +629,8 @@ public class WhileyFileLexer {
 			Export("export"),
 			Function("function"),
 			Method("method"),
+			// Lifetimes
+			This("this"),
 			// Expressions
 			All("all"),
 			No("no"),

--- a/modules/wyc/src/wyc/io/WhileyFilePrinter.java
+++ b/modules/wyc/src/wyc/io/WhileyFilePrinter.java
@@ -160,6 +160,8 @@ public class WhileyFilePrinter {
 			print((Stmt.Skip) stmt);
 		} else if(stmt instanceof Stmt.Switch) {
 			print((Stmt.Switch) stmt, indent);
+		} else if(stmt instanceof Stmt.NamedBlock) {
+			print((Stmt.NamedBlock) stmt, indent);
 		} else if(stmt instanceof Stmt.While) {
 			print((Stmt.While) stmt, indent);
 		} else if(stmt instanceof Stmt.VariableDeclaration) {
@@ -253,6 +255,11 @@ public class WhileyFilePrinter {
 		out.print("while ");
 		print(s.condition);
 		out.println();
+	}
+
+	public void print(Stmt.NamedBlock s, int indent) {
+		out.println(s.name + ":");
+		print(s.body,indent+1);
 	}
 
 	public void print(Stmt.While s, int indent) {
@@ -455,6 +462,18 @@ public class WhileyFilePrinter {
 			out.print(".");
 		}
 		out.print(e.name);
+		if (!e.lifetimeArguments.isEmpty()) {
+			out.print("<");
+			boolean firstTime = true;
+			for (String lifetime : e.lifetimeArguments) {
+				if (!firstTime) {
+					out.print(", ");
+				}
+				firstTime = false;
+				out.print(lifetime);
+			}
+			out.print(">");
+		}
 		out.print("(");
 		boolean firstTime = true;
 		for(Expr i : e.arguments) {
@@ -469,6 +488,18 @@ public class WhileyFilePrinter {
 
 	public void print(Expr.IndirectFunctionCall e) {
 		print(e.src);
+		if (!e.lifetimeArguments.isEmpty()) {
+			out.print("<");
+			boolean firstTime = true;
+			for (String lifetime : e.lifetimeArguments) {
+				if (!firstTime) {
+					out.print(", ");
+				}
+				firstTime = false;
+				out.print(lifetime);
+			}
+			out.print(">");
+		}
 		out.print("(");
 		boolean firstTime = true;
 		for(Expr i : e.arguments) {
@@ -483,6 +514,18 @@ public class WhileyFilePrinter {
 
 	public void print(Expr.IndirectMethodCall e) {
 		print(e.src);
+		if (!e.lifetimeArguments.isEmpty()) {
+			out.print("<");
+			boolean firstTime = true;
+			for (String lifetime : e.lifetimeArguments) {
+				if (!firstTime) {
+					out.print(", ");
+				}
+				firstTime = false;
+				out.print(lifetime);
+			}
+			out.print(">");
+		}
 		out.print("(");
 		boolean firstTime = true;
 		for(Expr i : e.arguments) {
@@ -571,7 +614,32 @@ public class WhileyFilePrinter {
 	}
 
 	public void print(Expr.Lambda e) {
-		out.print("&(");
+		out.print("&");
+		if (!e.contextLifetimes.isEmpty()) {
+			out.print("[");
+			boolean firstTime = true;
+			for (String lifetime : e.contextLifetimes) {
+				if (!firstTime) {
+					out.print(", ");
+				}
+				firstTime = false;
+				out.print(lifetime);
+			}
+			out.print("]");
+		}
+		if (!e.lifetimeParameters.isEmpty()) {
+			out.print("<");
+			boolean firstTime = true;
+			for (String lifetime : e.lifetimeParameters) {
+				if (!firstTime) {
+					out.print(", ");
+				}
+				firstTime = false;
+				out.print(lifetime);
+			}
+			out.print(">");
+		}
+		out.print("(");
 		boolean firstTime = true;
 		for(WhileyFile.Parameter p : e.parameters) {
 			if(!firstTime) {
@@ -665,6 +733,30 @@ public class WhileyFilePrinter {
 				out.print("method ");
 			} else {
 				out.print("function ");
+			}
+			if (!tt.contextLifetimes.isEmpty()) {
+				out.print("[");
+				boolean firstTime = true;
+				for (String lifetime : tt.contextLifetimes) {
+					if (!firstTime) {
+						out.print(", ");
+					}
+					firstTime = false;
+					out.print(lifetime);
+				}
+				out.print("]");
+			}
+			if (!tt.lifetimeParameters.isEmpty()) {
+				out.print("<");
+				boolean firstTime = true;
+				for (String lifetime : tt.lifetimeParameters) {
+					if (!firstTime) {
+						out.print(", ");
+					}
+					firstTime = false;
+					out.print(lifetime);
+				}
+				out.print(">");
 			}
 			printParameterTypes(tt.paramTypes);
 			out.print("->");

--- a/modules/wyc/src/wyc/lang/Expr.java
+++ b/modules/wyc/src/wyc/lang/Expr.java
@@ -27,6 +27,7 @@ package wyc.lang;
 
 import java.util.*;
 
+import wyc.builder.FlowTypeChecker;
 import wyc.io.WhileyFileLexer;
 import wycc.lang.Attribute;
 import wycc.lang.NameID;
@@ -207,9 +208,11 @@ public interface Expr extends SyntacticElement {
 	public static class AbstractFunctionOrMethod extends SyntacticElement.Impl implements Expr {
 		public final String name;
 		public final ArrayList<SyntacticType> paramTypes;
+		public final ArrayList<String> lifetimeParameters;
 		public Nominal.FunctionOrMethod type;
 
-		public AbstractFunctionOrMethod(String name, Collection<SyntacticType> paramTypes, Attribute... attributes) {
+		public AbstractFunctionOrMethod(String name, Collection<SyntacticType> paramTypes,
+				Collection<String> lifetimeParameters, Attribute... attributes) {
 			super(attributes);
 			this.name = name;
 			if(paramTypes != null) {
@@ -217,10 +220,16 @@ public interface Expr extends SyntacticElement {
 			} else {
 				this.paramTypes = null;
 			}
+			if(lifetimeParameters != null) {
+				this.lifetimeParameters = new ArrayList<String>(lifetimeParameters);
+			} else {
+				this.lifetimeParameters = null;
+			}
 		}
 
 		public AbstractFunctionOrMethod(String name,
 				Collection<SyntacticType> paramTypes,
+				Collection<String> lifetimeParameters,
 				Collection<Attribute> attributes) {
 			super(attributes);
 			this.name = name;
@@ -228,6 +237,11 @@ public interface Expr extends SyntacticElement {
 				this.paramTypes = new ArrayList<SyntacticType>(paramTypes);
 			} else {
 				this.paramTypes = null;
+			}
+			if(lifetimeParameters != null) {
+				this.lifetimeParameters = new ArrayList<String>(lifetimeParameters);
+			} else {
+				this.lifetimeParameters = null;
 			}
 		}
 
@@ -240,34 +254,40 @@ public interface Expr extends SyntacticElement {
 		public final NameID nid;
 
 		public FunctionOrMethod(NameID nid, Collection<SyntacticType> paramTypes,
-				Attribute... attributes) {
-			super(nid.name(), paramTypes, attributes);
+				Collection<String> lifetimeParameters, Attribute... attributes) {
+			super(nid.name(), paramTypes, lifetimeParameters, attributes);
 			this.nid = nid;
 		}
 
 		public FunctionOrMethod(NameID nid, Collection<SyntacticType> paramTypes,
-				Collection<Attribute> attributes) {
-			super(nid.name(), paramTypes, attributes);
+				Collection<String> lifetimeParameters, Collection<Attribute> attributes) {
+			super(nid.name(), paramTypes, lifetimeParameters, attributes);
 			this.nid = nid;
 		}
 	}
 
 	public static class Lambda extends SyntacticElement.Impl implements Expr {
 		public final ArrayList<WhileyFile.Parameter> parameters;
+		public final HashSet<String> contextLifetimes;
+		public final ArrayList<String> lifetimeParameters;
 		public Expr body;
 		public Nominal.FunctionOrMethod type;
 
-		public Lambda(Collection<WhileyFile.Parameter> parameters, Expr body,
-				Attribute... attributes) {
+		public Lambda(Collection<WhileyFile.Parameter> parameters, Collection<String> contextLifetimes,
+				Collection<String> lifetimeParameters, Expr body, Attribute... attributes) {
 			super(attributes);
 			this.parameters = new ArrayList<WhileyFile.Parameter>(parameters);
+			this.contextLifetimes = new HashSet<String>(contextLifetimes);
+			this.lifetimeParameters = new ArrayList<String>(lifetimeParameters);
 			this.body = body;
 		}
 
-		public Lambda(Collection<WhileyFile.Parameter> parameters, Expr body,
-				Collection<Attribute> attributes) {
+		public Lambda(Collection<WhileyFile.Parameter> parameters, Collection<String> contextLifetimes,
+				Collection<String> lifetimeParameters, Expr body, Collection<Attribute> attributes) {
 			super(attributes);
 			this.parameters = new ArrayList<WhileyFile.Parameter>(parameters);
+			this.contextLifetimes = new HashSet<String>(contextLifetimes);
+			this.lifetimeParameters = new ArrayList<String>(lifetimeParameters);
 			this.body = body;
 		}
 
@@ -564,22 +584,34 @@ public interface Expr extends SyntacticElement {
 		public final String name;
 		public Path.ID qualification;
 		public final ArrayList<Expr> arguments;
+		public final ArrayList<String> lifetimeArguments;
 
 		public AbstractInvoke(String name, Path.ID receiver,
-				Collection<Expr> arguments, Attribute... attributes) {
+				Collection<Expr> arguments, Collection<String> lifetimeArguments,
+				Attribute... attributes) {
 			super(attributes);
 			this.name = name;
 			this.qualification = receiver;
 			this.arguments = new ArrayList<Expr>(arguments);
+			if (lifetimeArguments != null) {
+				this.lifetimeArguments = new ArrayList<String>(lifetimeArguments);
+			} else {
+				this.lifetimeArguments = null;
+			}
 		}
 
 		public AbstractInvoke(String name, Path.ID receiver,
-				Collection<Expr> arguments,
+				Collection<Expr> arguments, Collection<String> lifetimeArguments,
 				Collection<Attribute> attributes) {
 			super(attributes);
 			this.name = name;
 			this.qualification = receiver;
 			this.arguments = new ArrayList<Expr>(arguments);
+			if (lifetimeArguments != null) {
+				this.lifetimeArguments = new ArrayList<String>(lifetimeArguments);
+			} else {
+				this.lifetimeArguments = null;
+			}
 		}
 
 		public Nominal result() {
@@ -591,14 +623,14 @@ public interface Expr extends SyntacticElement {
 		public final NameID nid;
 		
 		public FunctionOrMethodCall(NameID nid, Path.ID qualification, Collection<Expr> arguments,
-				Attribute... attributes) {
-			super(nid.name(),qualification,arguments,attributes);
+				Collection<String> lifetimeArguments, Attribute... attributes) {
+			super(nid.name(),qualification,arguments,lifetimeArguments,attributes);
 			this.nid = nid;
 		}
 
 		public FunctionOrMethodCall(NameID nid, Path.ID qualification, Collection<Expr> arguments,
-				Collection<Attribute> attributes) {
-			super(nid.name(),qualification,arguments,attributes);
+				Collection<String> lifetimeArguments, Collection<Attribute> attributes) {
+			super(nid.name(),qualification,arguments,lifetimeArguments,attributes);
 			this.nid = nid;
 		}
 		
@@ -617,13 +649,13 @@ public interface Expr extends SyntacticElement {
 		public Nominal.Method methodType;
 
 		public MethodCall(NameID nid, Path.ID qualification, Collection<Expr> arguments,
-				Attribute... attributes) {
-			super(nid,qualification,arguments,attributes);
+				Collection<String> lifetimeArguments, Attribute... attributes) {
+			super(nid,qualification,arguments,lifetimeArguments,attributes);
 		}
 
 		public MethodCall(NameID nid, Path.ID qualification, Collection<Expr> arguments,
-				Collection<Attribute> attributes) {
-			super(nid,qualification,arguments,attributes);
+				Collection<String> lifetimeArguments, Collection<Attribute> attributes) {
+			super(nid,qualification,arguments,lifetimeArguments,attributes);
 		}
 
 		public Nominal.Method type() {
@@ -632,7 +664,11 @@ public interface Expr extends SyntacticElement {
 		
 		public Nominal result() {
 			if (methodType.returns().size() == 1) {
-				return methodType.returns().get(0);
+				Nominal returnType = methodType.returns().get(0);
+				if (this.lifetimeArguments == null || this.lifetimeArguments.isEmpty()) {
+					return returnType;
+				}
+				return FlowTypeChecker.applySubstitution(methodType.raw().lifetimeParams(), this.lifetimeArguments, returnType);
 			} else {
 				throw new IllegalArgumentException("incorrect number of returns for function call");
 			}
@@ -654,12 +690,12 @@ public interface Expr extends SyntacticElement {
 
 		public FunctionCall(NameID nid, Path.ID qualification, Collection<Expr> arguments,
 				Attribute... attributes) {
-			super(nid,qualification,arguments,attributes);
+			super(nid,qualification,arguments,Collections.<String>emptyList(),attributes);
 		}
 
 		public FunctionCall(NameID nid, Path.ID qualification, Collection<Expr> arguments,
 				Collection<Attribute> attributes) {
-			super(nid,qualification,arguments,attributes);
+			super(nid,qualification,arguments,Collections.<String>emptyList(),attributes);
 		}
 
 		public Nominal.Function type() {
@@ -679,21 +715,26 @@ public interface Expr extends SyntacticElement {
 	Stmt {
 		public Expr src;
 		public final ArrayList<Expr> arguments;
+		public final ArrayList<String> lifetimeArguments;
 
 		public AbstractIndirectInvoke(Expr src,
 				Collection<Expr> arguments,
+				Collection<String> lifetimeArguments,
 				Attribute... attributes) {
 			super(attributes);
 			this.src = src;
 			this.arguments = new ArrayList<Expr>(arguments);
+			this.lifetimeArguments = lifetimeArguments == null ? null : new ArrayList<String>(lifetimeArguments);
 		}
 
 		public AbstractIndirectInvoke(Expr src,
 				Collection<Expr> arguments,
+				Collection<String> lifetimeArguments,
 				Collection<Attribute> attributes) {
 			super(attributes);
 			this.src = src;
 			this.arguments = new ArrayList<Expr>(arguments);
+			this.lifetimeArguments = lifetimeArguments == null ? null : new ArrayList<String>(lifetimeArguments);
 		}
 
 		public Nominal result() {
@@ -703,13 +744,13 @@ public interface Expr extends SyntacticElement {
 
 	public static abstract class IndirectFunctionOrMethodCall extends AbstractIndirectInvoke implements Multi {
 		public IndirectFunctionOrMethodCall(Expr src, Collection<Expr> arguments,
-				Attribute... attributes) {
-			super(src,arguments,attributes);
+				Collection<String> lifetimeArguments, Attribute... attributes) {
+			super(src,arguments,lifetimeArguments,attributes);
 		}
 
 		public IndirectFunctionOrMethodCall(Expr src, Collection<Expr> arguments,
-				Collection<Attribute> attributes) {
-			super(src,arguments,attributes);
+				Collection<String> lifetimeArguments, Collection<Attribute> attributes) {
+			super(src,arguments,lifetimeArguments,attributes);
 		}
 
 		public abstract Nominal.FunctionOrMethod type();
@@ -723,18 +764,22 @@ public interface Expr extends SyntacticElement {
 		public Nominal.Method methodType;
 
 		public IndirectMethodCall(Expr src, Collection<Expr> arguments,
-				Attribute... attributes) {
-			super(src,arguments,attributes);
+				Collection<String> lifetimeArguments, Attribute... attributes) {
+			super(src,arguments,lifetimeArguments,attributes);
 		}
 
 		public IndirectMethodCall(Expr src, Collection<Expr> arguments,
-				Collection<Attribute> attributes) {
-			super(src,arguments,attributes);
+				Collection<String> lifetimeArguments, Collection<Attribute> attributes) {
+			super(src,arguments,lifetimeArguments,attributes);
 		}
 
 		public Nominal result() {
 			if(methodType.returns().size() == 1) {
-				return methodType.returns().get(0);
+				Nominal returnType = methodType.returns().get(0);
+				if (this.lifetimeArguments == null || this.lifetimeArguments.isEmpty()) {
+					return returnType;
+				}
+				return FlowTypeChecker.applySubstitution(methodType.raw().lifetimeParams(), this.lifetimeArguments, returnType);
 			} else {
 				throw new IllegalArgumentException("incorrect number of returns for indirect method call");
 			}			
@@ -750,12 +795,12 @@ public interface Expr extends SyntacticElement {
 
 		public IndirectFunctionCall(Expr src, Collection<Expr> arguments,
 				Attribute... attributes) {
-			super(src,arguments,attributes);
+			super(src,arguments,Collections.<String>emptyList(),attributes);
 		}
 
 		public IndirectFunctionCall(Expr src, Collection<Expr> arguments,
 				Collection<Attribute> attributes) {
-			super(src,arguments,attributes);
+			super(src,arguments,Collections.<String>emptyList(),attributes);
 		}
 
 		public Nominal result() {
@@ -774,9 +819,11 @@ public interface Expr extends SyntacticElement {
 	public static class New extends SyntacticElement.Impl implements Expr,Stmt {
 		public Expr expr;
 		public Nominal.Reference type;
+		public String lifetime;
 
-		public New(Expr expr, Attribute... attributes) {
+		public New(Expr expr, String lifetime, Attribute... attributes) {
 			super(attributes);
+			this.lifetime = lifetime;
 			this.expr = expr;
 		}
 

--- a/modules/wyc/src/wyc/lang/Nominal.java
+++ b/modules/wyc/src/wyc/lang/Nominal.java
@@ -56,9 +56,9 @@ public abstract class Nominal {
 		return Nominal.construct(nominal, raw);
 	}
 
-	public static Reference Reference(Nominal element) {
-		Type.Reference nominal = Type.Reference(element.nominal());
-		Type.Reference raw = Type.Reference(element.raw());
+	public static Reference Reference(Nominal element, String lifetime) {
+		Type.Reference nominal = Type.Reference(element.nominal(), lifetime);
+		Type.Reference raw = Type.Reference(element.raw(), lifetime);
 		return new Reference(nominal,raw);
 	}
 

--- a/modules/wyc/src/wyc/lang/Stmt.java
+++ b/modules/wyc/src/wyc/lang/Stmt.java
@@ -261,6 +261,59 @@ public interface Stmt extends SyntacticElement {
 	}
 
 	/**
+	 * Represents a named block, which has the form:
+	 *
+	 * <pre>
+	 * NamedBlcok ::= LifetimeIdentifier ':' NewLine Block
+	 * </pre>
+	 *
+	 * As an example:
+	 *
+	 * <pre>
+	 * function sum():
+	 *   &this:int x = new:this x
+	 *   myblock:
+	 *     &myblock:int y = new:myblock y
+	 * </pre>
+	 */
+	public static final class NamedBlock extends SyntacticElement.Impl implements Stmt {
+		public final String name;
+		public final ArrayList<Stmt> body;
+
+		/**
+		 * Construct a named block from a given name and body of statements.
+		 *
+		 * @param name
+		 *            name of this named block.
+		 * @param body
+		 *            non-null collection which contains zero or more
+		 *            statements.
+		 * @param attributes
+		 */
+		public NamedBlock(String name, Collection<Stmt> body, Attribute... attributes) {
+			super(attributes);
+			this.name = name;
+			this.body = new ArrayList<Stmt>(body);
+		}
+
+		/**
+		 * Construct a named block from a given name and body of statements.
+		 *
+		 * @param name
+		 *            name of this named block.
+		 * @param body
+		 *            non-null collection which contains zero or more
+		 *            statements.
+		 * @param attributes
+		 */
+		public NamedBlock(String name, Collection<Stmt> body, Collection<Attribute> attributes) {
+			super(attributes);
+			this.name = name;
+			this.body = new ArrayList<Stmt>(body);
+		}
+	}
+
+	/**
 	 * Represents a while statement, which has the form:
 	 *
 	 * <pre>

--- a/modules/wyc/src/wyc/lang/SyntacticType.java
+++ b/modules/wyc/src/wyc/lang/SyntacticType.java
@@ -291,8 +291,12 @@ public interface SyntacticType extends SyntacticElement {
 	 */
 	public static final class Reference extends SyntacticElement.Impl implements NonUnion {
 		public final SyntacticType element;
-		public Reference(SyntacticType element, Attribute... attributes) {
+		public final String lifetime;
+		public final boolean lifetimeWasExplicit;
+		public Reference(SyntacticType element, String lifetime, boolean lifetimeWasExplicit, Attribute... attributes) {
 			this.element = element;
+			this.lifetime = lifetime;
+			this.lifetimeWasExplicit = lifetimeWasExplicit;
 		}
 	}
 
@@ -338,12 +342,16 @@ public interface SyntacticType extends SyntacticElement {
 			SyntacticElement.Impl implements NonUnion {
 		public final ArrayList<SyntacticType> returnTypes;
 		public final ArrayList<SyntacticType> paramTypes;
+		public final ArrayList<String> contextLifetimes;
+		public final ArrayList<String> lifetimeParameters;
 
 		public FunctionOrMethod(Collection<SyntacticType> returnTypes, Collection<SyntacticType> paramTypes,
-				Attribute... attributes) {
+				Collection<String> contextLifetimes, Collection<String> lifetimeParameters, Attribute... attributes) {
 			super(attributes);
 			this.returnTypes = new ArrayList<SyntacticType>(returnTypes);
 			this.paramTypes = new ArrayList<SyntacticType>(paramTypes);
+			this.contextLifetimes = new ArrayList<String>(contextLifetimes);
+			this.lifetimeParameters = new ArrayList<String>(lifetimeParameters);
 			for(SyntacticType t : paramTypes) {
 				if(t == null) {
 					throw new IllegalArgumentException("parameter cannot be null"); 
@@ -352,15 +360,22 @@ public interface SyntacticType extends SyntacticElement {
 			for(SyntacticType t : returnTypes) {
 				if(t == null) {
 					throw new IllegalArgumentException("return cannot be null"); 
+				}
+			}
+			for(String s : lifetimeParameters) {
+				if(s == null) {
+					throw new IllegalArgumentException("lifetime cannot be null");
 				}
 			}
 		}
 
 		public FunctionOrMethod(Collection<SyntacticType> returnTypes, Collection<SyntacticType> paramTypes,
-				Collection<Attribute> attributes) {
+				Collection<String> contextLifetimes, Collection<String> lifetimeParameters, Collection<Attribute> attributes) {
 			super(attributes);
 			this.returnTypes = new ArrayList<SyntacticType>(returnTypes);
 			this.paramTypes = new ArrayList<SyntacticType>(paramTypes);
+			this.contextLifetimes = new ArrayList<String>(contextLifetimes);
+			this.lifetimeParameters = new ArrayList<String>(lifetimeParameters);
 			for(SyntacticType t : paramTypes) {
 				if(t == null) {
 					throw new IllegalArgumentException("parameter cannot be null"); 
@@ -369,6 +384,11 @@ public interface SyntacticType extends SyntacticElement {
 			for(SyntacticType t : returnTypes) {
 				if(t == null) {
 					throw new IllegalArgumentException("return cannot be null"); 
+				}
+			}
+			for(String s : lifetimeParameters) {
+				if(s == null) {
+					throw new IllegalArgumentException("lifetime cannot be null");
 				}
 			}
 		}
@@ -379,23 +399,23 @@ public interface SyntacticType extends SyntacticElement {
 		public Function(Collection<SyntacticType> returnTypes, 
 				Collection<SyntacticType> paramTypes,
 				Attribute... attributes) {
-			super(returnTypes,paramTypes,attributes);
+			super(returnTypes,paramTypes,Collections.<String>emptySet(),Collections.<String>emptyList(),attributes);
 		}
 		public Function(Collection<SyntacticType> returnTypes, Collection<SyntacticType> paramTypes,
 				Collection<Attribute> attributes) {
-			super(returnTypes,paramTypes,attributes);
+			super(returnTypes,paramTypes,Collections.<String>emptySet(),Collections.<String>emptyList(),attributes);
 		}
 	}
 
 	public static class Method extends FunctionOrMethod
 	implements NonUnion {
-				public Method(Collection<SyntacticType> returnTypes, Collection<SyntacticType> paramTypes,
-				Attribute... attributes) {
-			super(returnTypes,paramTypes,attributes);
+		public Method(Collection<SyntacticType> returnTypes, Collection<SyntacticType> paramTypes,
+				Collection<String> contextLifetimes, Collection<String> lifetimeParameters, Attribute... attributes) {
+			super(returnTypes,paramTypes,contextLifetimes,lifetimeParameters,attributes);
 		}
 		public Method(Collection<SyntacticType> returnTypes, Collection<SyntacticType> paramTypes,
-				Collection<Attribute> attributes) {
-			super(returnTypes,paramTypes,attributes);
+				Collection<String> contextLifetimes, Collection<String> lifetimeParameters, Collection<Attribute> attributes) {
+			super(returnTypes,paramTypes,contextLifetimes,lifetimeParameters,attributes);
 		}
 	}
 }

--- a/modules/wyc/src/wyc/lang/WhileyFile.java
+++ b/modules/wyc/src/wyc/lang/WhileyFile.java
@@ -422,6 +422,7 @@ public final class WhileyFile implements CompilationUnit {
 	 */
 	public abstract class FunctionOrMethod extends NamedDeclaration {
 		public final ArrayList<Parameter> parameters;
+		public final ArrayList<String> lifetimeParameters;
 		public final ArrayList<Parameter> returns;
 		public final ArrayList<Stmt> statements;
 		public List<Expr> requires;
@@ -446,12 +447,14 @@ public final class WhileyFile implements CompilationUnit {
 		 */
 		public FunctionOrMethod(List<Modifier> modifiers, String name,
 				List<Parameter> returns, List<Parameter> parameters,
+				List<String> lifetimeParameters,
 				List<Expr> requires, List<Expr> ensures,
 				List<Stmt> statements,
 				Attribute... attributes) {
 			super(name, modifiers,attributes);
 			this.returns  = new ArrayList<Parameter>(returns);
 			this.parameters = new ArrayList<Parameter>(parameters);
+			this.lifetimeParameters = lifetimeParameters == null ? new ArrayList<String>() : new ArrayList<String>(lifetimeParameters);
 			this.requires = new ArrayList<Expr>(requires);
 			this.ensures = new ArrayList<Expr>(ensures);
 			this.statements = new ArrayList<Stmt>(statements);
@@ -503,8 +506,7 @@ public final class WhileyFile implements CompilationUnit {
 				List<Parameter> parameters, List<Expr> requires,
 				List<Expr> ensures,
 				List<Stmt> statements, Attribute... attributes) {
-			super(modifiers, name, returns, parameters, requires, ensures,
-					statements, attributes);
+			super(modifiers, name, returns, parameters, null, requires, ensures, statements, attributes);
 		}
 
 		public SyntacticType.Function unresolvedType() {
@@ -560,8 +562,9 @@ public final class WhileyFile implements CompilationUnit {
 		public Nominal.Method resolvedType;
 
 		public Method(List<Modifier> modifiers, String name, List<Parameter> returns, List<Parameter> parameters,
-				List<Expr> requires, List<Expr> ensures, List<Stmt> statements, Attribute... attributes) {
-			super(modifiers, name, returns, parameters, requires, ensures, statements, attributes);
+				List<String> lifetimeParameters, List<Expr> requires, List<Expr> ensures,
+				List<Stmt> statements, Attribute... attributes) {
+			super(modifiers, name, returns, parameters, lifetimeParameters, requires, ensures, statements, attributes);
 		}
 
 		public SyntacticType.Method unresolvedType() {
@@ -573,7 +576,8 @@ public final class WhileyFile implements CompilationUnit {
 			for (Parameter r : returns) {
 				returnTypes.add(r.type);
 			}
-			return new SyntacticType.Method(returnTypes, parameterTypes, attributes());
+			return new SyntacticType.Method(returnTypes, parameterTypes,
+					Collections.<String>emptySet(), lifetimeParameters, attributes());
 		}
 
 		public Nominal.Method resolvedType() {

--- a/modules/wyc/src/wyc/testing/AllInvalidTests.java
+++ b/modules/wyc/src/wyc/testing/AllInvalidTests.java
@@ -198,7 +198,7 @@ public class AllInvalidTests {
 			fail("Test compiled when it shouldn't have!");
 		} else if (r == WycMain.INTERNAL_FAILURE) {
 			// This indicates some other kind of internal failure.
-			fail("Test caused internal failure!");
+			fail("Test caused internal failure!\n" + output);
 		} else {
 			// Now, let's check the expected output against the file which
 			// contains the sample output for this test

--- a/modules/wyc/src/wyc/testing/AllValidTests.java
+++ b/modules/wyc/src/wyc/testing/AllValidTests.java
@@ -89,6 +89,7 @@ public class AllValidTests {
 		IGNORED.put("Import_Valid_5", "#492");
 		IGNORED.put("Intersection_Valid_1", "Issue ???");
 		IGNORED.put("Intersection_Valid_2", "Issue ???");
+		IGNORED.put("Lifetime_Lambda_Valid_4", "#641");
 		IGNORED.put("ListAccess_Valid_6", "Issue ???");
 		IGNORED.put("ListAccess_Valid_7", "Issue ???");
 		IGNORED.put("NegationType_Valid_3", "Issue ???");

--- a/modules/wyc/src/wyc/testing/AllValidVerificationTests.java
+++ b/modules/wyc/src/wyc/testing/AllValidVerificationTests.java
@@ -121,6 +121,7 @@ public class AllValidVerificationTests {
 		IGNORED.put("Lambda_Valid_3", "#344");
 		IGNORED.put("Lambda_Valid_4", "#344");
 		IGNORED.put("Lambda_Valid_7", "#344");
+		IGNORED.put("Lifetime_Lambda_Valid_4", "#298");
 		IGNORED.put("ListAccess_Valid_6", "Known Issue");
 		IGNORED.put("ListAssign_Valid_1", "#233");
 		IGNORED.put("ListAssign_Valid_6", "#233");

--- a/modules/wyc/src/wyc/testing/TestUtils.java
+++ b/modules/wyc/src/wyc/testing/TestUtils.java
@@ -102,7 +102,8 @@ public class TestUtils {
 	 * @throws IOException
 	 */
 	public static void execWyil(String wyilDir, Path.ID id) throws IOException {
-		Type.Method sig = Type.Method(Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+		Type.Method sig = Type.Method(Collections.<Type>emptyList(), Collections.<String>emptySet(),
+				Collections.<String>emptyList(), Collections.<Type>emptyList());
 		NameID name = new NameID(id,"test");
 		Build.Project project = initialiseProject(wyilDir);
 		new Interpreter(project,null).execute(name,sig);

--- a/modules/wyil/src/wyil/Main.java
+++ b/modules/wyil/src/wyil/Main.java
@@ -89,7 +89,8 @@ public class Main {
 			WyilFile wf = new WyilFileReader(args[0]).read();
 			new WyilFilePrinter(System.out).apply(wf);
 			// FIXME: this is all a hack for now
-			Type.Method sig = Type.Method(Collections.EMPTY_LIST, Collections.EMPTY_LIST);
+			Type.Method sig = Type.Method(Collections.<Type>emptyList(), Collections.<String>emptySet(),
+					Collections.<String>emptyList(), Collections.<Type>emptyList());
 			NameID name = new NameID(wf.id(),"test");
 			Build.Project project = initialiseProject(".");
 			Constant[] returns = new Interpreter(project,System.out).execute(name,sig);

--- a/modules/wyil/src/wyil/lang/Type.java
+++ b/modules/wyil/src/wyil/lang/Type.java
@@ -83,7 +83,7 @@ public abstract class Type {
 	// the following are strictly unnecessary, but since they occur very
 	// commonly it is helpful to provide them as constants.
 
-	public static final Reference T_REF_ANY = Reference(T_ANY);
+	// public static final Reference T_REF_ANY = Reference(T_ANY);
 
 	/**
 	 * The type representing all possible list types.
@@ -95,8 +95,8 @@ public abstract class Type {
 	 *
 	 * @param element
 	 */
-	public static final Type.Reference Reference(Type element) {
-		Type r = construct(K_REFERENCE, null, element);
+	public static final Type.Reference Reference(Type element, String lifetime) {
+		Type r = construct(K_REFERENCE, lifetime, element);
 		if (r instanceof Type.Reference) {
 			return (Type.Reference) r;
 		} else {
@@ -163,8 +163,10 @@ public abstract class Type {
 		}
 		for(int i=0;i!=returns.size();++i) {
 			rparams[i+params_size] = returns.get(i);
-		}		
-		Type r = construct(K_FUNCTION, params_size, rparams);
+		}
+		Type.FunctionOrMethod.Data data = new Type.FunctionOrMethod.Data(params_size,
+				Collections.<String>emptySet(), Collections.<String>emptyList());
+		Type r = construct(K_FUNCTION, data, rparams);
 		if (r instanceof Type.Function) {
 			return (Type.Function) r;
 		} else {
@@ -183,7 +185,9 @@ public abstract class Type {
 		Type[] rparams = new Type[params.length+returns.length];
 		System.arraycopy(params, 0, rparams, 0, params.length);
 		System.arraycopy(returns, 0, rparams, params.length, returns.length);
-		Type r = construct(K_FUNCTION, params.length, rparams);
+		Type.FunctionOrMethod.Data data = new Type.FunctionOrMethod.Data(params.length,
+				Collections.<String>emptySet(), Collections.<String>emptyList());
+		Type r = construct(K_FUNCTION, data, rparams);
 		if (r instanceof Type.Function) {
 			return (Type.Function) r;
 		} else {
@@ -197,7 +201,8 @@ public abstract class Type {
 	 *
 	 * @param element
 	 */
-	public static final Type.Method Method(List<Type> returns, List<Type> params) {
+	public static final Type.Method Method(List<Type> returns, Set<String> contextLifetimes,
+			List<String> lifetimeParameters, List<Type> params) {
 		Type[] rparams = new Type[params.size()+returns.size()];
 		int params_size = params.size();
 		for(int i=0;i!=params_size;++i) {
@@ -205,8 +210,10 @@ public abstract class Type {
 		}
 		for(int i=0;i!=returns.size();++i) {
 			rparams[i+params_size] = returns.get(i);
-		}			
-		Type r = construct(K_METHOD, params_size, rparams);
+		}
+		Type.FunctionOrMethod.Data data = new Type.FunctionOrMethod.Data(params_size,
+				contextLifetimes, lifetimeParameters);
+		Type r = construct(K_METHOD, data, rparams);
 		if (r instanceof Type.Method) {
 			return (Type.Method) r;
 		} else {
@@ -220,11 +227,14 @@ public abstract class Type {
 	 *
 	 * @param element
 	 */
-	public static final Type.Method Method(Type[] returns, Type... params) {
+	public static final Type.Method Method(Type[] returns, Set<String> contextLifetimes,
+			List<String> lifetimeParameters, Type... params) {
 		Type[] rparams = new Type[params.length+returns.length];
 		System.arraycopy(params, 0, rparams, 0, params.length);
 		System.arraycopy(returns, 0, rparams, params.length, returns.length);
-		Type r = construct(K_METHOD, params.length, rparams);
+		Type.FunctionOrMethod.Data data = new Type.FunctionOrMethod.Data(params.length,
+				contextLifetimes, lifetimeParameters);
+		Type r = construct(K_METHOD, data, rparams);
 		if (r instanceof Type.Method) {
 			return (Type.Method) r;
 		} else {
@@ -400,22 +410,36 @@ public abstract class Type {
 					fields.add(readString());
 				}
 				state.data = fields;
-			}  else if(state.kind == Type.K_LIST || state.kind == Type.K_SET) {
+			} else if(state.kind == Type.K_REFERENCE) {
+				state.data = readString(); // lifetime
+			} else if(state.kind == Type.K_LIST || state.kind == Type.K_SET) {
 				boolean nonEmpty = reader.read_bit();
 				state.data = nonEmpty;
 			} else if(state.kind == Type.K_FUNCTION || state.kind == Type.K_METHOD) {
+				ArrayList<String> contextLifetimes = readStringList();
+				ArrayList<String> lifetimeParameters = readStringList();
 				int numParameters = reader.read_uv();
-				state.data = numParameters;
+				state.data = new Type.FunctionOrMethod.Data(numParameters,
+						new HashSet<String>(contextLifetimes), lifetimeParameters);
 			}
 			return state;
 		}
 
 		private String readString() throws IOException {
-			String r = "";
+			StringBuilder r = new StringBuilder();
 			int nchars = reader.read_uv();
 			for(int i=0;i!=nchars;++i) {
 				char c = (char) reader.read_u16();
-				r = r + c;
+				r.append(c);
+			}
+			return r.toString();
+		}
+
+		private ArrayList<String> readStringList() throws IOException {
+			int len = reader.read_uv();
+			ArrayList<String> r = new ArrayList<String>(len);
+			for(int i=0;i!=len;++i) {
+				r.add(readString());
 			}
 			return r;
 		}
@@ -456,10 +480,15 @@ public abstract class Type {
 				for(String field : fields) {
 					writeString(field);
 				}
+			} else if(state.kind == Type.K_REFERENCE) {
+				writeString((String) state.data); // lifetime
 			} else if(state.kind == Type.K_LIST || state.kind == Type.K_SET) {
 				writer.write_bit((Boolean) state.data);
 			}  else if(state.kind == Type.K_FUNCTION || state.kind == Type.K_METHOD) {
-				writer.write_uv((Integer) state.data);				
+				Type.FunctionOrMethod.Data data = (Type.FunctionOrMethod.Data) state.data;
+				writeStringList(data.contextLifetimes);
+				writeStringList(data.lifetimeParameters);
+				writer.write_uv(data.numParams);
 			}
 		}
 
@@ -467,6 +496,13 @@ public abstract class Type {
 			writer.write_uv(str.length());
 			for (int i = 0; i != str.length(); ++i) {
 				writer.write_u16(str.charAt(i));
+			}
+		}
+
+		private void writeStringList(List<String> strl) throws IOException {
+			writer.write_uv(strl.size());
+			for (String str : strl) {
+				writeString(str);
 			}
 		}
 	}
@@ -479,10 +515,31 @@ public abstract class Type {
 	 * Determine whether type <code>t2</code> is an <i>explicit coercive
 	 * subtype</i> of type <code>t1</code>.
 	 */
-	public static boolean isExplicitCoerciveSubtype(Type t1, Type t2) {
+	public static boolean isExplicitCoerciveSubtype(Type t1, Type t2, LifetimeRelation lr) {
 		Automaton a1 = destruct(t1);
 		Automaton a2 = destruct(t2);
-		ExplicitCoercionOperator relation = new ExplicitCoercionOperator(a1,a2);
+		ExplicitCoercionOperator relation = new ExplicitCoercionOperator(a1,a2,lr);
+		return relation.isSubtype(0, 0);
+	}
+
+	/**
+	 * Determine whether type <code>t2</code> is an <i>explicit coercive
+	 * subtype</i> of type <code>t1</code>.
+	 */
+	public static boolean isExplicitCoerciveSubtype(Type t1, Type t2) {
+		return isExplicitCoerciveSubtype(t1, t2, LifetimeRelation.EMPTY);
+	}
+
+	/**
+	 * Determine whether type <code>t2</code> is a <i>subtype</i> of type
+	 * <code>t1</code> (written t1 :> t2). In other words, whether the set of
+	 * all possible values described by the type <code>t2</code> is a subset of
+	 * that described by <code>t1</code>.
+	 */
+	public static boolean isSubtype(Type t1, Type t2, LifetimeRelation lr) {
+		Automaton a1 = destruct(t1);
+		Automaton a2 = destruct(t2);
+		SubtypeOperator relation = new SubtypeOperator(a1,a2,lr);
 		return relation.isSubtype(0, 0);
 	}
 
@@ -493,10 +550,7 @@ public abstract class Type {
 	 * that described by <code>t1</code>.
 	 */
 	public static boolean isSubtype(Type t1, Type t2) {
-		Automaton a1 = destruct(t1);
-		Automaton a2 = destruct(t2);
-		SubtypeOperator relation = new SubtypeOperator(a1,a2);
-		return relation.isSubtype(0, 0);
+		return isSubtype(t1, t2, LifetimeRelation.EMPTY);
 	}
 
 	/**
@@ -874,6 +928,9 @@ public abstract class Type {
 			int elemIdx = automaton.states[0].children[0];
 			return construct(Automata.extract(automaton,elemIdx));
 		}
+		public String lifetime() {
+			return (String) automaton.states[0].data;
+		}
 	}
 
 	/**
@@ -1154,16 +1211,79 @@ public abstract class Type {
 		FunctionOrMethod(Automaton automaton) {
 			super(automaton);
 		}
-		
+
+		public static final class Data implements Comparable<Data> {
+			public final int numParams;
+			public final List<String> contextLifetimes;
+			public final List<String> lifetimeParameters;
+
+			public Data(int numParams, Set<String> contextLifetimes, List<String> lifetimeParameters) {
+				this.numParams = numParams;
+				this.contextLifetimes = new ArrayList<String>(contextLifetimes);
+				this.contextLifetimes.remove("*");
+				Collections.sort(this.contextLifetimes);
+				this.lifetimeParameters = new ArrayList<String>(lifetimeParameters);
+			}
+
+			@Override
+			public int hashCode() {
+				return 31 * (31 * numParams + contextLifetimes.hashCode()) + lifetimeParameters.hashCode();
+			}
+
+			@Override
+			public boolean equals(Object obj) {
+				if (this == obj) return true;
+				if (obj == null) return false;
+				if (this.getClass() != obj.getClass()) return false;
+				Data other = (Data) obj;
+				if (this.numParams != other.numParams) return false;
+				if (!this.contextLifetimes.equals(other.contextLifetimes)) {
+					return false;
+				}
+				if (!this.lifetimeParameters.equals(other.lifetimeParameters)) {
+					return false;
+				}
+				return true;
+			}
+
+			@Override
+			public int compareTo(Data other) {
+				int r = Integer.compare(this.numParams, other.numParams);
+				if (r != 0) return r;
+				r = compareLists(this.contextLifetimes, other.contextLifetimes);
+				if (r != 0) return r;
+				return compareLists(this.lifetimeParameters, other.lifetimeParameters);
+			}
+
+			private static int compareLists(List<String> my, List<String> other) {
+				Iterator<String> it1 = my.iterator();
+				Iterator<String> it2 = other.iterator();
+				while (true) {
+					if (it1.hasNext()) {
+						if (it2.hasNext()) {
+							int r = it1.next().compareTo(it2.next());
+							if (r != 0) return r;
+						} else {
+							return 1;
+						}
+					} else if (it2.hasNext()) {
+						return -1;
+					} else {
+						return 0;
+					}
+				}
+			}
+		}
+
 		/**
-		 * Get the parameter types of this function or method type.
+		 * Get the return types of this function or method type.
 		 *
 		 * @return
 		 */
 		public ArrayList<Type> returns() {
 			Automaton.State state = automaton.states[0];
 			int[] fields = state.children;
-			int numParams = (Integer) state.data;
+			int numParams = ((Data) state.data).numParams;
 			ArrayList<Type> r = new ArrayList<Type>();
 			for(int i=numParams;i<fields.length;++i) {
 				r.add(construct(Automata.extract(automaton, fields[i])));
@@ -1179,12 +1299,34 @@ public abstract class Type {
 		public ArrayList<Type> params() {
 			Automaton.State state = automaton.states[0];
 			int[] fields = state.children;
-			int numParams = (Integer) state.data;
+			int numParams = ((Data) state.data).numParams;
 			ArrayList<Type> r = new ArrayList<Type>();
 			for(int i=0;i<numParams;++i) {
 				r.add(construct(Automata.extract(automaton, fields[i])));
 			}
 			return r;
+		}
+
+		/**
+		 * Get the context lifetimes of this function or method type.
+		 *
+		 * @return
+		 */
+		public Set<String> contextLifetimes() {
+			Automaton.State state = automaton.states[0];
+			Data data = (Data) state.data;
+			return new LinkedHashSet<String>(data.contextLifetimes);
+		}
+
+		/**
+		 * Get the lifetime parameters of this function or method type.
+		 *
+		 * @return
+		 */
+		public ArrayList<String> lifetimeParams() {
+			Automaton.State state = automaton.states[0];
+			Data data = (Data) state.data;
+			return new ArrayList<String>(data.lifetimeParameters);
 		}
 	}
 
@@ -1303,7 +1445,12 @@ public abstract class Type {
 			middle = state.data.toString();
 			break;
 		case K_REFERENCE:
-			middle = "&" + toString(state.children[0], visited, headers, automaton);
+			middle = "&";
+			String lifetime = (String) state.data;
+			if (!"*".equals(lifetime)) {
+				middle += lifetime + ":";
+			}
+			middle += toString(state.children[0], visited, headers, automaton);
 			break;
 		case K_NEGATION: {
 			middle = "!" + toBracesString(state.children[0], visited, headers, automaton);
@@ -1364,8 +1511,9 @@ public abstract class Type {
 		case K_METHOD:
 		case K_FUNCTION: {
 			String parameters = "";
-			int[] children = state.children;			;
-			int numParameters = (Integer) state.data;
+			int[] children = state.children;
+			Type.FunctionOrMethod.Data data = (Type.FunctionOrMethod.Data) state.data;
+			int numParameters = data.numParams;
 			for (int i = 0; i != numParameters; ++i) {
 				if (i!=0) {
 					parameters += ",";
@@ -1379,11 +1527,40 @@ public abstract class Type {
 				}
 				returns += toString(children[i], visited, headers, automaton);
 			}
-			if(state.kind == K_FUNCTION) {
-				middle = "function(" + parameters + ")->(" + returns + ")";
-			} else {
-				middle = "method(" + parameters + ")->(" + returns + ")";
-			}			
+			StringBuilder sb = new StringBuilder();
+			sb.append(state.kind == K_FUNCTION ? "function" : "method");
+			if (!data.contextLifetimes.isEmpty()) {
+				sb.append('[');
+				boolean first = true;
+				for (String l : data.contextLifetimes) {
+					if (!first) {
+						sb.append(',');
+					} else {
+						first = false;
+					}
+					sb.append(l);
+				}
+				sb.append(']');
+			}
+			if (!data.lifetimeParameters.isEmpty()) {
+				sb.append('<');
+				boolean first = true;
+				for (String l : data.lifetimeParameters) {
+					if (!first) {
+						sb.append(',');
+					} else {
+						first = false;
+					}
+					sb.append(l);
+				}
+				sb.append('>');
+			}
+			sb.append('(');
+			sb.append(parameters);
+			sb.append(")->(");
+			sb.append(returns);
+			sb.append(')');
+			middle = sb.toString();
 			break;
 		}
 		default:
@@ -1764,33 +1941,33 @@ public abstract class Type {
 		}
 	}
 
-	public static void main(String[] args) {
-		//Type from = fromString("(null,null)");
-		//Type to = fromString("X<[X]>");
-		Type from = fromString("!(!{int x,int z} | !{int x,int y})");
-		Type to = fromString("{string name,...}");
-		System.out.println(from + " :> " + to + " = " + isSubtype(from, to));
-		System.out.println(from + " & " + to + " = " + intersect(from,to));
-		//System.out.println(from + " - " + to + " = " + intersect(from,Type.Negation(to)));
-		//System.out.println(to + " - " + from + " = " + intersect(to,Type.Negation(from)));
-		//System.out.println("!" + from + " & !" + to + " = "
-		//		+ intersect(Type.Negation(from), Type.Negation(to)));
-	}
-
-	public static Type linkedList(int n) {
-		NameID label = new NameID(Trie.fromString(""),"X");
-		return Recursive(label,innerLinkedList(n));
-	}
-
-	public static Type innerLinkedList(int n) {
-		if(n == 0) {
-			return Nominal(new NameID(Trie.fromString(""),"X"));
-		} else {
-			Type leaf = Reference(innerLinkedList(n-1));
-			HashMap<String,Type> fields = new HashMap<String,Type>();
-			fields.put("next", Union(T_NULL,leaf));
-			fields.put("data", T_BOOL);
-			return Record(false,fields);
-		}
-	}
+//	public static void main(String[] args) {
+//		//Type from = fromString("(null,null)");
+//		//Type to = fromString("X<[X]>");
+//		Type from = fromString("!(!{int x,int z} | !{int x,int y})");
+//		Type to = fromString("{string name,...}");
+//		System.out.println(from + " :> " + to + " = " + isSubtype(from, to));
+//		System.out.println(from + " & " + to + " = " + intersect(from,to));
+//		//System.out.println(from + " - " + to + " = " + intersect(from,Type.Negation(to)));
+//		//System.out.println(to + " - " + from + " = " + intersect(to,Type.Negation(from)));
+//		//System.out.println("!" + from + " & !" + to + " = "
+//		//		+ intersect(Type.Negation(from), Type.Negation(to)));
+//	}
+//
+//	public static Type linkedList(int n) {
+//		NameID label = new NameID(Trie.fromString(""),"X");
+//		return Recursive(label,innerLinkedList(n));
+//	}
+//
+//	public static Type innerLinkedList(int n) {
+//		if(n == 0) {
+//			return Nominal(new NameID(Trie.fromString(""),"X"));
+//		} else {
+//			Type leaf = Reference(innerLinkedList(n-1));
+//			HashMap<String,Type> fields = new HashMap<String,Type>();
+//			fields.put("next", Union(T_NULL,leaf));
+//			fields.put("data", T_BOOL);
+//			return Record(false,fields);
+//		}
+//	}
 }

--- a/modules/wyil/src/wyil/util/TypeExpander.java
+++ b/modules/wyil/src/wyil/util/TypeExpander.java
@@ -237,7 +237,7 @@ public class TypeExpander {
 			for(int i=0;i!=tt_returns_size;++i) {
 				myChildren[i+tt_params_size] = getTypeHelper(tt_returns.get(i),maximallyConsumed,states,roots);
 			}
-			myData = tt_params_size;
+			myData = new Type.FunctionOrMethod.Data(tt_params_size, tt.contextLifetimes(), tt.lifetimeParams());
 			myKind = tt instanceof Type.Function ? Type.K_FUNCTION
 					: Type.K_METHOD;			
 		}else {

--- a/modules/wyil/src/wyil/util/interpreter/Interpreter.java
+++ b/modules/wyil/src/wyil/util/interpreter/Interpreter.java
@@ -299,8 +299,12 @@ public class Interpreter {
 			// In this case, we don't need to do anything because the value is
 			// already of the correct type.
 			return value;
-		}
-		if (to instanceof Type.Record) {
+		} else if (type instanceof Type.Reference && to instanceof Type.Reference) {
+			if (Type.isSubtype(((Type.Reference) to).element(), ((Type.Reference) type).element())) {
+				// OK, it's just the lifetime that differs.
+				return value;
+			}
+		} else if (to instanceof Type.Record) {
 			return convert(value, (Type.Record) to, context);
 		} else if (to instanceof Type.Array) {
 			return convert(value, (Type.Array) to, context);
@@ -941,7 +945,8 @@ public class Interpreter {
 
 		@Override
 		public wyil.lang.Type type() {
-			return wyil.lang.Type.Reference(value.type());
+			// TODO: extend wyil.lang.Codes.NewObject with a lifetime and use it
+			return wyil.lang.Type.Reference(value.type(), "*");
 		}
 
 	}

--- a/modules/wyil/src/wyil/util/type/ExplicitCoercionOperator.java
+++ b/modules/wyil/src/wyil/util/type/ExplicitCoercionOperator.java
@@ -59,8 +59,8 @@ import wyil.lang.Type;
  */
 public class ExplicitCoercionOperator extends SubtypeOperator {
 
-	public ExplicitCoercionOperator(Automaton fromAutomata, Automaton toAutomata) {
-		super(fromAutomata,toAutomata);
+	public ExplicitCoercionOperator(Automaton fromAutomata, Automaton toAutomata, LifetimeRelation lr) {
+		super(fromAutomata,toAutomata,lr);
 	}
 
 	@Override

--- a/modules/wyil/src/wyil/util/type/LifetimeRelation.java
+++ b/modules/wyil/src/wyil/util/type/LifetimeRelation.java
@@ -1,0 +1,140 @@
+package wyil.util.type;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.Stack;
+
+/**
+ * This relation tracks the partial order among lifetimes.
+ */
+public class LifetimeRelation {
+
+	/**
+	 * These are all lifetime parameters to the current method. There is no
+	 * order between lifetimes in this set.
+	 */
+	private final Set<String> parameters;
+
+	/**
+	 * These are lifetimes declared by named blocks. These lifetimes are totally
+	 * ordered according to their position in the stack. Each lifetime in
+	 * {@link #parameters} outlives all block lifetimes.
+	 */
+	private final Stack<String> blocks;
+
+	/**
+	 * Create a new and empty lifetime relation.
+	 */
+	public LifetimeRelation() {
+		this.parameters = new HashSet<String>();
+		this.blocks = new Stack<String>();
+	}
+
+	/**
+	 * Create an independent copy of the given lifetime relation.
+	 *
+	 * @param lifetimeRelation
+	 */
+	public LifetimeRelation(LifetimeRelation lifetimeRelation) {
+		this.parameters = new HashSet<String>(lifetimeRelation.parameters);
+		this.blocks = new Stack<String>();
+		this.blocks.addAll(lifetimeRelation.blocks);
+	}
+
+	/**
+	 * Check whether the first (outer) lifetime outlives the second (inner)
+	 * lifetime.
+	 *
+	 * @param outerLifetime
+	 * @param innerLifetime
+	 * @return
+	 */
+	public boolean outlives(String outerLifetime, String innerLifetime) {
+		if (outerLifetime.equals("*")) {
+			// * outlives everything
+			return true;
+		}
+
+		if (outerLifetime.equals(innerLifetime)) {
+			return true;
+		}
+
+		// Check whether the inner lifetime is from a named block.
+		int innerIndex = this.blocks.indexOf(innerLifetime);
+		if (innerIndex != -1) {
+			// All parameters are ordered before blocks.
+			if (this.parameters.contains(outerLifetime)) {
+				return true;
+			}
+
+			// Maybe another block at lower stack position?
+			int outerIndex = this.blocks.indexOf(outerLifetime);
+			if (outerIndex != -1 && outerIndex < innerIndex) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Add a method's lifetime parameters to this relation.
+	 *
+	 * @param lifetimeParameters
+	 */
+	public void addParameters(Collection<String> lifetimeParameters) {
+		this.parameters.addAll(lifetimeParameters);
+	}
+
+	/**
+	 * Enter a named block to this relation.
+	 *
+	 * @param lifetime
+	 */
+	public void startNamedBlock(String lifetime) {
+		this.blocks.push(lifetime);
+	}
+
+	/**
+	 * Remove the named block with the given name from this relation. It also
+	 * removes inner blocks in case that the given block is not the latest one.
+	 *
+	 * @param lifetime
+	 */
+	public void endNamedBlock(String lifetime) {
+		int i = this.blocks.lastIndexOf(lifetime);
+		if (i != -1) {
+			this.blocks.subList(i, this.blocks.size()).clear();
+		}
+	}
+
+	/**
+	 * Replace this lifetime relation with the merge result of the given two
+	 * relations.
+	 *
+	 * @param first
+	 * @param second
+	 */
+	public void replaceWithMerge(LifetimeRelation first, LifetimeRelation second) {
+		this.parameters.clear();
+		this.blocks.clear();
+
+		this.parameters.addAll(first.parameters);
+		this.parameters.retainAll(second.parameters);
+		Iterator<String> it1 = first.blocks.iterator();
+		Iterator<String> it2 = second.blocks.iterator();
+		while (it1.hasNext() && it2.hasNext()) {
+			String b1 = it1.next();
+			String b2 = it2.next();
+			if (b1.equals(b2)) {
+				this.blocks.push(b1);
+			} else {
+				break;
+			}
+		}
+	}
+
+	public final static LifetimeRelation EMPTY = new LifetimeRelation();
+}

--- a/modules/wyil/src/wyil/util/type/LifetimeSubstitution.java
+++ b/modules/wyil/src/wyil/util/type/LifetimeSubstitution.java
@@ -1,0 +1,262 @@
+package wyil.util.type;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import java.util.Set;
+
+import wyautl_old.lang.Automaton;
+import wyautl_old.lang.Automaton.State;
+import wyil.lang.Type;
+
+/**
+ * This class can be used to substitute lifetimes, i.e. instantiate lifetime
+ * parameters with actual lifetime arguments.
+ * 
+ * It is not a trivial task, as you must take care to not capture lifetime
+ * parameters within nested method types. This is especially difficult when
+ * types are recursive.
+ * 
+ * The method type defined by
+ * 
+ * <pre>
+ * type mymethod is method<a>(&*:mymethod)->(&a:mymethod)
+ * </pre>
+ * 
+ * returns
+ * 
+ * <pre>
+ * X<&a:Y<method<a>(&Y)->(X)>>
+ * </pre>
+ * 
+ * Assume the argument for parameter "a" is "b". You cannot just replace "&a:"
+ * with "&b:", because it would also affect the nested return type. Instead, we
+ * need this type here:
+ * 
+ * <pre>
+ * &b:X<method<a>(&X)->( Y<&a:Z<method<a>(&Z)->(Y)>> )>
+ * </pre>
+ *
+ * It can be further simplified to
+ * 
+ * <pre>
+ * &b:X<method<a>(&X)->(&a:X)>
+ * </pre>
+ * 
+ * Note that the original type has two different references, but the substituted
+ * and minimized type has three reference types with different lifetimes. They
+ * cannot be mapped to the same automaton state. Substitution might yield an
+ * automaton with more states!
+ */
+public class LifetimeSubstitution {
+
+	/**
+	 * The substitution to apply
+	 */
+	private final Map<String, String> substitution;
+
+	/**
+	 * The substituted type
+	 */
+	private final Type substituted;
+
+	/**
+	 * The states in the original automaton
+	 */
+	private final State[] originalStates;
+
+	/**
+	 * The states in our new automaton
+	 */
+	private final List<State> substitutedStates;
+
+	/**
+	 * For each old state we can have several new states. They differ in the set
+	 * of lifetimes that had to be substituted.
+	 */
+	private final Map<Integer, List<SubstitutedState>> mapping;
+
+	/**
+	 * Apply the substitution.
+	 *
+	 * @param original
+	 *            the original automaton
+	 * @param substitution
+	 *            the substitution to apply
+	 */
+	public LifetimeSubstitution(Type original, Map<String, String> substitution) {
+		this.substitution = substitution;
+
+		if (substitution.isEmpty()) {
+			// easy!
+			substituted = original;
+
+			// we do not need those fields
+			originalStates = null;
+			substitutedStates = null;
+			mapping = null;
+		} else {
+			// initialize all fields
+			originalStates = Type.destruct(original).states;
+			substitutedStates = new ArrayList<State>(originalStates.length);
+			mapping = new HashMap<>(originalStates.length);
+
+			// Start with the root state
+			SubstitutedState newRootState = copy(0, Collections.<String>emptySet());
+			if (newRootState.substitutedLiffetimes.isEmpty()) {
+				// nothing got substituted!
+				substituted = original;
+			} else {
+				// Construct the resulting type.
+				substituted = Type.construct(new Automaton(substitutedStates));
+			}
+		}
+	}
+
+	/**
+	 * Get the substituted type.
+	 *
+	 * @return the substituted type
+	 */
+	public Type getType() {
+		return substituted;
+	}
+
+	/**
+	 * Copy the given state into our new automaton while applying the
+	 * substitution but ignoring the given lifetimes.
+	 *
+	 * @param index
+	 *            the state index from the original automaton
+	 * @param ignored
+	 *            do not apply substitution for these lifetimes
+	 * @return
+	 */
+	private SubstitutedState copy(int index, Set<String> ignored) {
+		List<SubstitutedState> mapped = mapping.get(index);
+		if (mapped == null) {
+			mapped = new LinkedList<>();
+			mapping.put(index, mapped);
+		} else {
+			outer: for (SubstitutedState entry : mapped) {
+				if (ignored.containsAll(entry.ignoredLifetimes)) {
+					// This entry might be suitable for us, but only if it did
+					// not substitute any lifetime that should be ignored now.
+					for (String substitutedLifetime : entry.substitutedLiffetimes) {
+						if (ignored.contains(substitutedLifetime)) {
+							// no, cannot re-use that one
+							continue outer;
+						}
+					}
+					return entry;
+				}
+			}
+		}
+
+		// OK, we need to copy that state.
+		SubstitutedState substitutedState = new SubstitutedState(
+				substitutedStates.size(), // next available index
+				ignored,
+				new HashSet<String>()
+		);
+		mapped.add(substitutedState);
+		State state = new State(originalStates[index]);
+		substitutedStates.add(state);
+
+		switch (state.kind) {
+		case Type.K_REFERENCE:
+			// If it is a reference, then we might have to fix the lifetime
+			String lifetime = (String) state.data;
+			if (!ignored.contains(lifetime)) {
+				String replacement = substitution.get(lifetime);
+				if (replacement != null) {
+					// OK, we need to replace
+					substitutedState.substitutedLiffetimes.add(lifetime);
+					state.data = replacement;
+				}
+			}
+			break;
+
+		case Type.K_FUNCTION:
+		case Type.K_METHOD:
+			// We need to apply the substitution to the context lifetimes
+			Type.FunctionOrMethod.Data data = (Type.FunctionOrMethod.Data) state.data;
+			if (!data.contextLifetimes.isEmpty()) {
+				ListIterator<String> it = data.contextLifetimes.listIterator();
+				boolean updated = false;
+				while (it.hasNext()) {
+					String lifetime2 = it.next();
+					if (!ignored.contains(lifetime2)) {
+						String replacement = substitution.get(lifetime2);
+						if (replacement != null) {
+							// OK, we need to replace
+							substitutedState.substitutedLiffetimes.add(lifetime2);
+							it.set(replacement);
+							updated = true;
+						}
+					}
+				}
+				if (updated) {
+					// Context lifetimes should be sorted
+					Collections.sort(data.contextLifetimes);
+				}
+			}
+
+			// We need to ignore lifetime parameters when recursing to the children children.
+			if (!data.lifetimeParameters.isEmpty()) {
+				ignored = new HashSet<String>(ignored);
+				ignored.addAll(data.lifetimeParameters);
+			}
+			break;
+
+		default:
+		}
+
+		if (state.children.length != 0) {
+			// We cannot yet know which lifetimes will be substituted, but need
+			// to specify something before we enter the children.
+			// Overestimating does not harm, so we assume that all lifetimes
+			// that should be substituted actually will be substituted
+			// But we keep track of which lifetimes got substituted in the children.
+			Set<String> childSubstituted = new HashSet<String>(substitutedState.substitutedLiffetimes);
+			substitutedState.substitutedLiffetimes.addAll(substitution.keySet());
+			substitutedState.substitutedLiffetimes.removeAll(ignored);
+
+			// Now copy all children
+			for (int i = 0; i < state.children.length; ++i) {
+				SubstitutedState child = copy(state.children[i], ignored);
+				if (child != substitutedState) {
+					// remember the substituted lifetimes
+					// but only if that child is not directly recursively
+					// referring to us :)
+					childSubstituted.addAll(child.substitutedLiffetimes);
+				}
+
+				// fix the index
+				state.children[i] = child.newStateIndex;
+			}
+
+			// Update the substituted lifetimes
+			substitutedState.substitutedLiffetimes.retainAll(childSubstituted);
+		}
+
+		return substitutedState;
+	}
+
+	private static class SubstitutedState {
+		private final int newStateIndex;
+		private final Set<String> ignoredLifetimes;
+		private final Set<String> substitutedLiffetimes;
+
+		private SubstitutedState(int newStateIndex, Set<String> ignoredLifetimes, Set<String> substitutedLiffetimes) {
+			this.newStateIndex = newStateIndex;
+			this.ignoredLifetimes = ignoredLifetimes;
+			this.substitutedLiffetimes = substitutedLiffetimes;
+		}
+	}
+}

--- a/modules/wyil/src/wyil/util/type/SubtypeOperator.java
+++ b/modules/wyil/src/wyil/util/type/SubtypeOperator.java
@@ -78,15 +78,35 @@ import wyil.lang.Type;
 public class SubtypeOperator {
 	protected final Automaton from;
 	protected final Automaton to;
+	private final Map<String, String> fromLifetimeSubstitution;
+	private final Map<String, String> toLifetimeSubstitution;
+	private final LifetimeRelation lifetimeRelation;
 	private final BitSet assumptions;
 
-	public SubtypeOperator(Automaton from, Automaton to) {
+	public SubtypeOperator(Automaton from, Automaton to, LifetimeRelation lr) {
 		this.from = from;
 		this.to = to;
+		this.lifetimeRelation = lr;
+		this.fromLifetimeSubstitution = Collections.emptyMap();
+		this.toLifetimeSubstitution = Collections.emptyMap();
 		// matrix is twice the size to accommodate positive and negative signs
 		this.assumptions = new BitSet((2*from.size()) * (to.size()*2));
 		//System.out.println("FROM: " + from);
 		//System.out.println("TO:   " + to);
+	}
+
+	private SubtypeOperator(SubtypeOperator sto, Map<String, String> fromLifetimeSubstitution,
+			Map<String, String> toLifetimeSubstitution) {
+		this.from = sto.from;
+		this.to = sto.to;
+		this.fromLifetimeSubstitution = new HashMap<String, String>(sto.fromLifetimeSubstitution);
+		prependLifetimes(this.fromLifetimeSubstitution);
+		this.fromLifetimeSubstitution.putAll(fromLifetimeSubstitution);
+		this.toLifetimeSubstitution = new HashMap<String, String>(sto.toLifetimeSubstitution);
+		prependLifetimes(this.toLifetimeSubstitution);
+		this.toLifetimeSubstitution.putAll(toLifetimeSubstitution);
+		this.lifetimeRelation = sto.lifetimeRelation;
+		this.assumptions = sto.assumptions;
 	}
 
 	/**
@@ -194,9 +214,50 @@ public class SubtypeOperator {
 				if(fromSign || toSign) {
 					int fromChild = fromState.children[0];
 					int toChild = toState.children[0];
-					return isIntersection(fromChild, fromSign, toChild, toSign)
-						|| isIntersection(fromChild, !fromSign, toChild, !toSign);
+
+					if (fromSign && toSign) {
+						// "Is there any value in both &a:A and &b:B ?"
+						//
+						// This is equivalent to the question "Is there any value in both &A and &B?"
+						// If there is a value in both &a:A and &b:B, then we can take that value
+						// and change its lifetime to *. It will then be in both &A and &B.
+						// If there is a value in both &A and &B, then it is also in both &a:A and &b:B
+						// because the lifetime * outlives a and b.
+						//
+						// Finally, there is a value in both &A and &B iff the types A and B intersect.
+						return isIntersection(fromChild, true, toChild, true);
+					} else {
+						String fromLifetime = applyFromLifetimeSubstitution((String) fromState.data);
+						String toLifetime = applyToLifetimeSubstitution((String) toState.data);
+
+						if (fromSign) {
+							// Equivalent to the negation of "is &a:A (fromType) a subtype of &b:B (toType)?"
+							return !(
+								// &a:A is a subtype of &b:B iff all these are true:
+								// a outlives b
+								lifetimeRelation.outlives(fromLifetime, toLifetime)
+								// A is a subtype of B
+								&& !isIntersection(fromChild, true, toChild, false)
+								// B is a subtype of A
+								&& !isIntersection(fromChild, false, toChild, true)
+							);
+						} else {
+							// Equivalent to the negation of "is &b:B (toType) a subtype of &a:A (fromType)?"
+							return !(
+								// &b:B is a subtype of &a:A iff all these are true:
+								// b outlives a
+								lifetimeRelation.outlives(toLifetime, fromLifetime)
+								// B is a subtype of A
+								&& !isIntersection(fromChild, false, toChild, true)
+								// A is a subtype of B
+								&& !isIntersection(fromChild, true, toChild, false)
+							);
+						}
+					}
 				}
+
+				// An inverted reference type always contains the value "null".
+				// Both are inverted, so they intersect with "null".
 				return true;
 			case K_MAP:
 			case K_TUPLE:  {
@@ -239,49 +300,85 @@ public class SubtypeOperator {
 					// nary nodes
 					int[] fromChildren = fromState.children;
 					int[] toChildren = toState.children;
-					int fromNumParams = (Integer) fromState.data;
-					int toNumParams = (Integer) toState.data;
+					Type.FunctionOrMethod.Data fromData = (Type.FunctionOrMethod.Data) fromState.data;
+					Type.FunctionOrMethod.Data toData = (Type.FunctionOrMethod.Data) toState.data;
+					int fromNumParams = fromData.numParams;
+					int toNumParams = toData.numParams;
+					List<String> fromLifetimeParameters = fromData.lifetimeParameters;
+					List<String> toLifetimeParameters = toData.lifetimeParameters;
 
 					if (fromSign && toSign) {
 						// Two intersecting method types must have the same number
-						// of parameters and returns.
-						if (fromChildren.length != toChildren.length || fromNumParams != toNumParams) {
+						// of parameters, returns and lifetime parameters.
+						if (fromChildren.length != toChildren.length
+								|| fromNumParams != toNumParams
+								|| fromLifetimeParameters.size() != toLifetimeParameters.size()){
 							return false;
 						}
+						// Context lifetimes do not matter, because we can always choose
+						// a method without context lifetimes to find an intersecting method.
+					} else {
+						// Now we have one of the following:
+						// fromSign == true: negation of "is fromType a subtype of toType?"
+						// toSign  ==  true: negation of "is toType a subtype of fromType?"
 
+						// Two method types can only be subtypes of each other if they have
+						// the same number of parameters, returns and lifetime parameters.
+						if (fromChildren.length != toChildren.length
+								|| fromNumParams != toNumParams
+								|| fromLifetimeParameters.size() != toLifetimeParameters.size()){
+							return true; // true means "not subtype"
+						}
+
+						// The supertype must contain all context lifetimes of the subtype
+						List<String> fromContextLifetimes = applyFromLifetimeSubstitution(fromData.contextLifetimes);
+						List<String> toContextLifetimes = applyToLifetimeSubstitution(toData.contextLifetimes);
+						if (fromSign) {
+							if (!toContextLifetimes.containsAll(fromContextLifetimes)) {
+								return true;
+							}
+						} else {
+							if (!fromContextLifetimes.containsAll(toContextLifetimes)) {
+								return true;
+							}
+						}
+					}
+
+					// Calculate the substitutions for lifetime parameters
+					Map<String, String> fromLifetimeSubstitution = buildLifetimeSubstitution(fromLifetimeParameters);
+					Map<String, String> toLifetimeSubstitution = buildLifetimeSubstitution(toLifetimeParameters);
+					SubtypeOperator sto = this;
+					if (!fromLifetimeSubstitution.isEmpty() || !toLifetimeSubstitution.isEmpty()) {
+						sto = new SubtypeOperator(this, fromLifetimeSubstitution, toLifetimeSubstitution);
+					}
+
+					if (fromSign && toSign) {
 						// Two intersecting method types must have intersecting return types.
 						// Parameter types can always be chosen as "any".
 						for (int i = fromNumParams; i < fromChildren.length; ++i) {
-							if (!isIntersection(fromChildren[i], true, toChildren[i], true)) {
+							if (!sto.isIntersection(fromChildren[i], true, toChildren[i], true)) {
 								return false;
 							}
 						}
 						return true;
 					}
 
-					// Now we have one of the following:
-					// fromSign == true: negation of "is fromType a subtype of toType?"
-					// toSign  ==  true: negation of "is toType a subtype of fromType?"
-
-					// Two method types can only be subtypes of each other if they have
-					// the same number of parameters and returns.
-					if (fromChildren.length != toChildren.length || fromNumParams != toNumParams) {
-						return true; // true means "not subtype"
-					}
+					// here we have the subtype test again...
 
 					// Parameter types are contra-variant
 					for (int i = 0; i < fromNumParams; ++i) {
-						if (isIntersection(fromChildren[i], !fromSign, toChildren[i], !toSign)) {
+						if (sto.isIntersection(fromChildren[i], !fromSign, toChildren[i], !toSign)) {
 							return true;
 						}
 					}
 
 					// Return types are co-variant
 					for (int i = fromNumParams; i < fromChildren.length; ++i) {
-						if (isIntersection(fromChildren[i], fromSign, toChildren[i], toSign)) {
+						if (sto.isIntersection(fromChildren[i], fromSign, toChildren[i], toSign)) {
 							return true;
 						}
 					}
+
 					return false;
 				}
 				return true;
@@ -341,6 +438,62 @@ public class SubtypeOperator {
 		}
 
 		return !fromSign || !toSign;
+	}
+
+	private static Map<String, String> buildLifetimeSubstitution(List<String> lifetimeParameters) {
+		if (lifetimeParameters.isEmpty()) {
+			return Collections.emptyMap();
+		}
+		Map<String, String> substitution = new HashMap<String, String>();
+		int i = 0;
+		for (String lifetime : lifetimeParameters) {
+			substitution.put(lifetime, "$" + (i++));
+		}
+		return substitution;
+	}
+
+	private static void prependLifetimes(Map<String, String> substitution) {
+		for (Map.Entry<String, String> entry : substitution.entrySet()) {
+			entry.setValue("$" + entry.getValue());
+		}
+	}
+
+	private String applyFromLifetimeSubstitution(String lifetime) {
+		String replacement = fromLifetimeSubstitution.get(lifetime);
+		if (replacement != null) {
+			return replacement;
+		}
+		return lifetime;
+	}
+
+	private String applyToLifetimeSubstitution(String lifetime) {
+		String replacement = toLifetimeSubstitution.get(lifetime);
+		if (replacement != null) {
+			return replacement;
+		}
+		return lifetime;
+	}
+
+	private List<String> applyFromLifetimeSubstitution(List<String> lifetimes) {
+		if (lifetimes.isEmpty() || fromLifetimeSubstitution.isEmpty()) {
+			return lifetimes;
+		}
+		List<String> replacement = new ArrayList<String>(lifetimes.size());
+		for (String lifetime : lifetimes) {
+			replacement.add(applyFromLifetimeSubstitution(lifetime));
+		}
+		return replacement;
+	}
+
+	private List<String> applyToLifetimeSubstitution(List<String> lifetimes) {
+		if (lifetimes.isEmpty() || toLifetimeSubstitution.isEmpty()) {
+			return lifetimes;
+		}
+		List<String> replacement = new ArrayList<String>(lifetimes.size());
+		for (String lifetime : lifetimes) {
+			replacement.add(applyToLifetimeSubstitution(lifetime));
+		}
+		return replacement;
 	}
 
 	/**

--- a/modules/wyil/src/wyil/util/type/TypeAlgorithms.java
+++ b/modules/wyil/src/wyil/util/type/TypeAlgorithms.java
@@ -108,9 +108,9 @@ public final class TypeAlgorithms {
 				Boolean nid2 = (Boolean) s2.data;
 				return nid1.toString().compareTo(nid2.toString());
 			} else if(s1.kind == Type.K_FUNCTION || s1.kind == Type.K_METHOD) {
-				int s1NumParams = (Integer) s1.data;
-				int s2NumParams = (Integer) s2.data;				
-				return Integer.compare(s1NumParams, s2NumParams);
+				Type.FunctionOrMethod.Data s1Data = (Type.FunctionOrMethod.Data) s1.data;
+				Type.FunctionOrMethod.Data s2Data = (Type.FunctionOrMethod.Data) s2.data;
+				return s1Data.compareTo(s2Data);
 			} else {
 				String str1 = (String) s1.data;
 				String str2 = (String) s2.data;
@@ -772,7 +772,7 @@ public final class TypeAlgorithms {
 
 	private static boolean isSubtype(int fromIndex, int toIndex,
 			Automaton automaton) {
-		SubtypeOperator op = new SubtypeOperator(automaton,automaton);
+		SubtypeOperator op = new SubtypeOperator(automaton,automaton,LifetimeRelation.EMPTY);
 		return op.isSubtype(fromIndex, toIndex);
 	}
 
@@ -1057,6 +1057,7 @@ public final class TypeAlgorithms {
 			case Type.K_SET:
 				return intersectSetsOrLists(fromIndex,fromSign,from,toIndex,toSign,to,allocations,states);
 			case Type.K_REFERENCE:
+				return intersectCompounds(fromIndex,fromSign,from,toIndex,toSign,to,fromState.data,allocations,states);
 			case Type.K_MAP:
 				return intersectCompounds(fromIndex,fromSign,from,toIndex,toSign,to,null,allocations,states);
 			case Type.K_NEGATION:

--- a/modules/wyil/src/wyil/util/type/TypeTester.java
+++ b/modules/wyil/src/wyil/util/type/TypeTester.java
@@ -97,7 +97,8 @@ public class TypeTester {
 					return false;
 				}
 				int length = schildren.length;
-				int sNumParams = (Integer) state.data;
+				Type.FunctionOrMethod.Data data = (Type.FunctionOrMethod.Data) state.data;
+				int sNumParams = data.numParams;
 				// First, do parameters (which are contravariant).
 				for(int i=0;i<sNumParams;++i) {
 					int schild = schildren[i];

--- a/modules/wyjc/src/wyjc/Wyil2JavaBuilder.java
+++ b/modules/wyjc/src/wyjc/Wyil2JavaBuilder.java
@@ -334,7 +334,8 @@ public class Wyil2JavaBuilder implements Builder {
 		codes.add(new Bytecode.Load(0, strArr));
 		codes.add(new Bytecode.Invoke(WHILEYUTIL, "systemConsole", ft1,
 				Bytecode.InvokeMode.STATIC));
-		Type.Method wyft = Type.Method(new Type[0], WHILEY_SYSTEM_T);
+		Type.Method wyft = Type.Method(new Type[0], Collections.<String>emptySet(),
+				Collections.<String>emptyList(), WHILEY_SYSTEM_T);
 		JvmType.Function ft3 = convertFunType(wyft);
 		codes.add(new Bytecode.Invoke(owner, nameMangle("main", wyft), ft3,
 				Bytecode.InvokeMode.STATIC));

--- a/modules/wyrt/src/whiley/io/File.whiley
+++ b/modules/wyrt/src/whiley/io/File.whiley
@@ -55,13 +55,13 @@ public type Reader is  {
 }
 
 public method Reader(string fileName) -> Reader:
-    NativeFile this = NativeFileReader(fileName)
+    NativeFile reader = NativeFileReader(fileName)
     return {
-        readAll: &( -> read(this)),
-        read: &(uint n -> read(this,n)),
-        hasMore: &( -> hasMore(this)),
-        close: &( -> close(this)),
-        available: &( -> available(this))
+        readAll: &( -> read(reader)),
+        read: &(uint n -> read(reader,n)),
+        hasMore: &( -> hasMore(reader)),
+        close: &( -> close(reader)),
+        available: &( -> available(reader))
     }
 
 // ====================================================
@@ -70,11 +70,11 @@ public method Reader(string fileName) -> Reader:
 type Writer is whiley.io.Writer.Writer
 
 public method Writer(string fileName) -> Writer:
-    NativeFile this = NativeFileWriter(fileName)
+    NativeFile reader = NativeFileWriter(fileName)
     return {
-        write: &(byte[] data -> write(this,data)),
-        close: &( -> close(this)),
-        flush: &( -> flush(this))
+        write: &(byte[] data -> write(reader,data)),
+        close: &( -> close(reader)),
+        flush: &( -> flush(reader))
     }
 
 // ====================================================

--- a/modules/wyrt/src/whiley/lang/Stack.whiley
+++ b/modules/wyrt/src/whiley/lang/Stack.whiley
@@ -36,31 +36,31 @@ public function create(int max) -> Stack:
         length: 0
     }
 
-public function size(Stack this) -> int:
-    return this.length
+public function size(Stack stack) -> int:
+    return stack.length
 
 /**
  * Return the top element of the "stack".
  */
-public function top(Stack this) -> int:
+public function top(Stack stack) -> int:
     //
-    return this.items[this.length-1]
+    return stack.items[stack.length-1]
 
 
 /**
  * Push an element onto the "stack".
  */
-public function push(Stack this, int element) -> (Stack r):
+public function push(Stack stack, int element) -> (Stack r):
     //
-    this.items[this.length] = element
-    this.length = this.length + 1
-    return this
+    stack.items[stack.length] = element
+    stack.length = stack.length + 1
+    return stack
 
 /**
  * Pop an element off the "stack".
  */
-public function pop(Stack this) -> (Stack r):
+public function pop(Stack stack) -> (Stack r):
     //
-    this.length = this.length - 1
+    stack.length = stack.length - 1
     //
-    return this
+    return stack

--- a/tests/invalid/ConstrainedRecord_Invalid_1.whiley
+++ b/tests/invalid/ConstrainedRecord_Invalid_1.whiley
@@ -1,7 +1,7 @@
 
 type tup is {int y, int x}
 
-type point is ({int y, int x} this) where (this.x > 0) && (this.y > 0)
+type point is ({int y, int x} _this) where (_this.x > 0) && (_this.y > 0)
 
 function f(point p) -> point:
     return p

--- a/tests/invalid/DefiniteAssign_Invalid_4.whiley
+++ b/tests/invalid/DefiniteAssign_Invalid_4.whiley
@@ -1,5 +1,5 @@
-method f(any this) :
-    debug this
+method f(any _this) :
+    debug _this
 
 method g() :
     f(x)

--- a/tests/invalid/FunctionRef_Invalid_5.whiley
+++ b/tests/invalid/FunctionRef_Invalid_5.whiley
@@ -1,6 +1,6 @@
 type Proc is &{int data}
 
-method read(Proc this, int x) -> int:
+method read(Proc _this, int x) -> int:
     return x + 1
 
 type Func is {

--- a/tests/invalid/FunctionRef_Invalid_7.sysout
+++ b/tests/invalid/FunctionRef_Invalid_7.sysout
@@ -1,3 +1,3 @@
 ../../tests/invalid/FunctionRef_Invalid_7.whiley:6: insufficient arguments for function or method invocation
-    return this->func(arg)
-           ^^^^^^^^^^^^^^^
+    return _this->func(arg)
+           ^^^^^^^^^^^^^^^^

--- a/tests/invalid/FunctionRef_Invalid_7.whiley
+++ b/tests/invalid/FunctionRef_Invalid_7.whiley
@@ -2,5 +2,5 @@ type Proc is &{
     function func(bool,int)->bool
 }
 
-method test(Proc this, bool arg) -> bool:
-    return this->func(arg)
+method test(Proc _this, bool arg) -> bool:
+    return _this->func(arg)

--- a/tests/invalid/Lifetime_Invalid_1.sysout
+++ b/tests/invalid/Lifetime_Invalid_1.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Lifetime_Invalid_1.whiley:2: expected type &int, found &this:int
+    &*:int ptr1 = this:new 42
+                  ^^^^^^^^^^^

--- a/tests/invalid/Lifetime_Invalid_1.whiley
+++ b/tests/invalid/Lifetime_Invalid_1.whiley
@@ -1,0 +1,2 @@
+public export method test():
+    &*:int ptr1 = this:new 42

--- a/tests/invalid/Lifetime_Invalid_2.sysout
+++ b/tests/invalid/Lifetime_Invalid_2.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Lifetime_Invalid_2.whiley:4: expected type &this:int, found &myblock:int
+        x = myblock:new 1
+        ^

--- a/tests/invalid/Lifetime_Invalid_2.whiley
+++ b/tests/invalid/Lifetime_Invalid_2.whiley
@@ -1,0 +1,4 @@
+public export method test():
+    &this:int x = this:new 1
+    myblock:
+        x = myblock:new 1

--- a/tests/invalid/Lifetime_Invalid_3.sysout
+++ b/tests/invalid/Lifetime_Invalid_3.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Lifetime_Invalid_3.whiley:1: use of undeclared lifetime
+method foo() -> &this:int:
+                 ^^^^

--- a/tests/invalid/Lifetime_Invalid_3.whiley
+++ b/tests/invalid/Lifetime_Invalid_3.whiley
@@ -1,0 +1,5 @@
+method foo() -> &this:int:
+    return this:new 1
+
+public export method test():
+    foo()

--- a/tests/invalid/Lifetime_Invalid_4.sysout
+++ b/tests/invalid/Lifetime_Invalid_4.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Lifetime_Invalid_4.whiley:2: expected type &int, found &this:int
+    return this:new 1
+           ^^^^^^^^^^

--- a/tests/invalid/Lifetime_Invalid_4.whiley
+++ b/tests/invalid/Lifetime_Invalid_4.whiley
@@ -1,0 +1,5 @@
+method foo() -> &*:int:
+    return this:new 1
+
+public export method test():
+    foo()

--- a/tests/invalid/Lifetime_Invalid_5.sysout
+++ b/tests/invalid/Lifetime_Invalid_5.sysout
@@ -1,0 +1,6 @@
+../../tests/invalid/Lifetime_Invalid_5.whiley:16: unable to resolve name (m(&int,&int) is ambiguous
+	found: Lifetime_Invalid_5:m : method<a>(&a:int,&a:int)->(int) instantiated with <*>
+	found: Lifetime_Invalid_5:m : method<a>(&a:int,&int)->(int) instantiated with <*>
+	found: Lifetime_Invalid_5:m : method<a>(&int,&a:int)->(int) instantiated with <*>)
+    m(new 1, new 2)
+    ^^^^^^^^^^^^^^^

--- a/tests/invalid/Lifetime_Invalid_5.whiley
+++ b/tests/invalid/Lifetime_Invalid_5.whiley
@@ -1,0 +1,16 @@
+// test lifetime inference with lifetime overloading but same types
+
+method <a> m(&a:int x, &a:int y) -> int:
+    return 1
+
+method <a> m(&a:int x, &*:int y) -> int:
+    return 2
+
+method <a> m(&*:int x, &a:int y) -> int:
+    return 3
+
+public export method test():
+    // variant1: (&*:int, &*:int) <--
+    // variant2: (&*:int, &*:int) <--
+    // variant3: (&*:int, &*:int) <--
+    m(new 1, new 2)

--- a/tests/invalid/Lifetime_Invalid_6.sysout
+++ b/tests/invalid/Lifetime_Invalid_6.sysout
@@ -1,0 +1,5 @@
+../../tests/invalid/Lifetime_Invalid_6.whiley:12: unable to resolve name (m(&this:int,&this:int) is ambiguous
+	found: Lifetime_Invalid_6:m : method<a,b>(&a:int,&b:int)->(int) instantiated with <this, this>
+	found: Lifetime_Invalid_6:m : method<a>(&a:int,&a:int)->(int) instantiated with <this>)
+    m(this:new 1, this:new 2)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/invalid/Lifetime_Invalid_6.whiley
+++ b/tests/invalid/Lifetime_Invalid_6.whiley
@@ -1,0 +1,12 @@
+// test lifetime inference with lifetime overloading but same types
+
+method <a> m(&a:int x, &a:int y) -> int:
+    return 1
+
+method <a, b> m(&a:int x, &b:int y) -> int:
+    return 2
+
+public export method test():
+    // variant1: (&this:int, &this:int) <--
+    // variant2: (&this:int, &this:int) <--
+    m(this:new 1, this:new 2)

--- a/tests/invalid/Lifetime_Invalid_7.sysout
+++ b/tests/invalid/Lifetime_Invalid_7.sysout
@@ -1,0 +1,5 @@
+../../tests/invalid/Lifetime_Invalid_7.whiley:16: unable to resolve name (m(&int,&this:int,bool) is ambiguous
+	found: Lifetime_Invalid_7:m : method<a,b>(&a:int|&b:bool,&a:int,bool)->(&b:int) instantiated with <this, *>
+	found: Lifetime_Invalid_7:m : method<a>(&int,&a:int,int|bool)->(&a:int) instantiated with <this>)
+    m(new 1, this:new 2, true)
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/invalid/Lifetime_Invalid_7.whiley
+++ b/tests/invalid/Lifetime_Invalid_7.whiley
@@ -1,0 +1,16 @@
+// test lifetime inference with lifetime overloading and different types
+
+method <a, b> m((&a:int)|(&b:bool) x, &a:int y, bool z) -> &b:int:
+    return b:new 1
+
+method <a> m(&a:bool x, &a:int y, bool z) -> &a:int:
+    return a:new 2
+
+method <a> m(&*:int x, &a:int y, int|bool z) -> &a:int:
+    return a:new 3
+
+public export method test():
+    // variant1: <this, *> ((&this:int)|(&*:bool) x, &this:int, bool z)
+    // variant2: no
+    // variant3: <this> (&this:int x, &this:int y, int|bool z)
+    m(new 1, this:new 2, true)

--- a/tests/invalid/Lifetime_Invalid_8.sysout
+++ b/tests/invalid/Lifetime_Invalid_8.sysout
@@ -1,0 +1,5 @@
+../../tests/invalid/Lifetime_Invalid_8.whiley:10: unable to resolve name (m(&int,&this:int) is ambiguous
+	found: Lifetime_Invalid_8:m : method<a,b>(&a:int|&b:bool,&a:int|&b:int)->() instantiated with <*, this>
+	found: Lifetime_Invalid_8:m : method<a,b>(&a:int|&b:bool,&a:int|&b:int)->() instantiated with <this, *>)
+    m(x, y)
+    ^^^^^^^

--- a/tests/invalid/Lifetime_Invalid_8.whiley
+++ b/tests/invalid/Lifetime_Invalid_8.whiley
@@ -1,0 +1,10 @@
+// test lifetime inference with lifetime overloading and different types
+
+method <a, b> m((&a:int)|(&b:bool) x, (&a:int)|(&b:int) y):
+
+public export method test():
+    // <this, *> --> ((&this:int)|(&*:bool), &this:int)
+    // <*, this> --> ((&*:int)|(&this:bool), &this:int)
+    (&*:int)|(&*:bool) x = *:new 1
+    &this:int y = this:new 1
+    m(x, y)

--- a/tests/invalid/Lifetime_Lambda_Invalid_1.sysout
+++ b/tests/invalid/Lifetime_Lambda_Invalid_1.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Lifetime_Lambda_Invalid_1.whiley:4: expected type method<a>(&a:int,&a:int)->(&a:int), found method<a>(&a:int,&int)->(&a:int)
+    method<a>(&a:int, &a:int)->(&a:int) m = &<a>(&a:int x, &int y -> a:new 1)
+                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/invalid/Lifetime_Lambda_Invalid_1.whiley
+++ b/tests/invalid/Lifetime_Lambda_Invalid_1.whiley
@@ -1,0 +1,4 @@
+// wrong method type
+
+public export method test():
+    method<a>(&a:int, &a:int)->(&a:int) m = &<a>(&a:int x, &int y -> a:new 1)

--- a/tests/invalid/Lifetime_Lambda_Invalid_2.sysout
+++ b/tests/invalid/Lifetime_Lambda_Invalid_2.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Lifetime_Lambda_Invalid_2.whiley:4: expected type method<a>(&a:int,&int)->(&int), found method<a>(&a:int,&int)->(&a:int)
+    method<a>(&a:int, &int)->(&*:int) m = &<a>(&a:int x, &int y -> a:new 1)
+                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/invalid/Lifetime_Lambda_Invalid_2.whiley
+++ b/tests/invalid/Lifetime_Lambda_Invalid_2.whiley
@@ -1,0 +1,4 @@
+// wrong method type
+
+public export method test():
+    method<a>(&a:int, &int)->(&*:int) m = &<a>(&a:int x, &int y -> a:new 1)

--- a/tests/invalid/Lifetime_Lambda_Invalid_3.sysout
+++ b/tests/invalid/Lifetime_Lambda_Invalid_3.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Lifetime_Lambda_Invalid_3.whiley:4: expected type method<a,b>()->(&int), found method<a>()->(&int)
+    method<a, b>()->(&int) m = &<a>(-> new 1)
+                               ^^^^^^^^^^^^^^

--- a/tests/invalid/Lifetime_Lambda_Invalid_3.whiley
+++ b/tests/invalid/Lifetime_Lambda_Invalid_3.whiley
@@ -1,0 +1,4 @@
+// wrong method type
+
+public export method test():
+    method<a, b>()->(&int) m = &<a>(-> new 1)

--- a/tests/invalid/Lifetime_Lambda_Invalid_4.sysout
+++ b/tests/invalid/Lifetime_Lambda_Invalid_4.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Lifetime_Lambda_Invalid_4.whiley:4: use of undeclared lifetime
+    method()->(&this:int) m = &(-> this:new 1)
+                                   ^^^^

--- a/tests/invalid/Lifetime_Lambda_Invalid_4.whiley
+++ b/tests/invalid/Lifetime_Lambda_Invalid_4.whiley
@@ -1,0 +1,4 @@
+// missing context lifetime
+
+public export method test():
+    method()->(&this:int) m = &(-> this:new 1)

--- a/tests/invalid/Lifetime_Lambda_Invalid_5.sysout
+++ b/tests/invalid/Lifetime_Lambda_Invalid_5.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Lifetime_Lambda_Invalid_5.whiley:7: lifetime 'this' cannot be dereferenced here
+    return &(->*x)
+               ^^

--- a/tests/invalid/Lifetime_Lambda_Invalid_5.whiley
+++ b/tests/invalid/Lifetime_Lambda_Invalid_5.whiley
@@ -1,0 +1,7 @@
+// missing context lifetime
+
+type mymethod is method()->(int)
+
+public export method test()->mymethod:
+    &this:int x = this:new 1
+    return &(->*x)

--- a/tests/invalid/Lifetime_Lambda_Invalid_6.sysout
+++ b/tests/invalid/Lifetime_Lambda_Invalid_6.sysout
@@ -1,0 +1,3 @@
+../../tests/invalid/Lifetime_Lambda_Invalid_6.whiley:7: expected type Lifetime_Lambda_Invalid_6:mymethod, found method[this]()->(int)
+    return &[this](-> (*x) + (*(new 1)))
+           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/tests/invalid/Lifetime_Lambda_Invalid_6.whiley
+++ b/tests/invalid/Lifetime_Lambda_Invalid_6.whiley
@@ -1,0 +1,7 @@
+// missing context lifetime
+
+type mymethod is method()->(int)
+
+public export method test()->mymethod:
+    &this:int x = new 1
+    return &[this](-> (*x) + (*(new 1)))

--- a/tests/invalid/MethodCall_Invalid_1.sysout
+++ b/tests/invalid/MethodCall_Invalid_1.sysout
@@ -1,3 +1,3 @@
 ../../tests/invalid/MethodCall_Invalid_1.whiley:5: unable to resolve name (no match for f(&int,int))
-    f(this, 1)
-    ^^^^^^^^^^
+    f(_this, 1)
+    ^^^^^^^^^^^

--- a/tests/invalid/MethodCall_Invalid_1.whiley
+++ b/tests/invalid/MethodCall_Invalid_1.whiley
@@ -1,5 +1,5 @@
 method f(int x) -> int:
     return 1
 
-method main(&int this):
-    f(this, 1)
+method main(&int _this):
+    f(_this, 1)

--- a/tests/invalid/MethodCall_Invalid_2.sysout
+++ b/tests/invalid/MethodCall_Invalid_2.sysout
@@ -1,4 +1,4 @@
 ../../tests/invalid/MethodCall_Invalid_2.whiley:7: unable to resolve name (no match for f(&int,int)
 	found: MethodCall_Invalid_2:f : method(MethodCall_Invalid_2:dummy,int)->(int))
-    f(this, 1)
-    ^^^^^^^^^^
+    f(_this, 1)
+    ^^^^^^^^^^^

--- a/tests/invalid/MethodCall_Invalid_2.whiley
+++ b/tests/invalid/MethodCall_Invalid_2.whiley
@@ -1,7 +1,7 @@
 type dummy is &{int x}
 
-method f(dummy this, int x) -> int:
+method f(dummy _this, int x) -> int:
     return 1
 
-method main(&int this) :
-    f(this, 1)
+method main(&int _this) :
+    f(_this, 1)

--- a/tests/invalid/MethodCall_Invalid_3.sysout
+++ b/tests/invalid/MethodCall_Invalid_3.sysout
@@ -1,3 +1,3 @@
 ../../tests/invalid/MethodCall_Invalid_3.whiley:2: record required, got: int[]
-    this.f(1)
-    ^^^^^^^^^
+    _this.f(1)
+    ^^^^^^^^^^

--- a/tests/invalid/MethodCall_Invalid_3.whiley
+++ b/tests/invalid/MethodCall_Invalid_3.whiley
@@ -1,2 +1,2 @@
-method main(int[] this) :
-    this.f(1)
+method main(int[] _this) :
+    _this.f(1)

--- a/tests/invalid/Parameter_Invalid_1.sysout
+++ b/tests/invalid/Parameter_Invalid_1.sysout
@@ -1,3 +1,3 @@
-../../tests/invalid/Parameter_Invalid_1.whiley:1: parameter already declared
+../../tests/invalid/Parameter_Invalid_1.whiley:1: name already declared
 function f(int x, int x) -> int:
                       ^

--- a/tests/invalid/Parsing_Invalid_5.sysout
+++ b/tests/invalid/Parsing_Invalid_5.sysout
@@ -1,3 +1,3 @@
-../../tests/invalid/Parsing_Invalid_5.whiley:2: variable already declared
+../../tests/invalid/Parsing_Invalid_5.whiley:2: name already declared
     int x = x
     ^^^^^

--- a/tests/invalid/Parsing_Invalid_6.sysout
+++ b/tests/invalid/Parsing_Invalid_6.sysout
@@ -1,3 +1,3 @@
-../../tests/invalid/Parsing_Invalid_6.whiley:3: variable already declared
+../../tests/invalid/Parsing_Invalid_6.whiley:3: name already declared
     int x = x
     ^^^^^

--- a/tests/invalid/ProcessAccess_Invalid_1.sysout
+++ b/tests/invalid/ProcessAccess_Invalid_1.sysout
@@ -1,3 +1,3 @@
 ../../tests/invalid/ProcessAccess_Invalid_1.whiley:6: invalid assignment expression
-    this.op = 1
-    ^^^^^^^
+    _this.op = 1
+    ^^^^^^^^

--- a/tests/invalid/ProcessAccess_Invalid_1.whiley
+++ b/tests/invalid/ProcessAccess_Invalid_1.whiley
@@ -2,6 +2,6 @@ type etype is {int mode, ...}
 
 type Ptype is &etype
 
-method get(Ptype this) -> int:
-    this.op = 1
-    return this.mode
+method get(Ptype _this) -> int:
+    _this.op = 1
+    return _this.mode

--- a/tests/invalid/ProcessAccess_Invalid_2.sysout
+++ b/tests/invalid/ProcessAccess_Invalid_2.sysout
@@ -1,3 +1,3 @@
 ../../tests/invalid/ProcessAccess_Invalid_2.whiley:6: expected type ProcessAccess_Invalid_2:pState, found &{int x,int z}
-    this = new {z: 4, x: 3}
-    ^^^^
+    _this = new {z: 4, x: 3}
+    ^^^^^

--- a/tests/invalid/ProcessAccess_Invalid_2.whiley
+++ b/tests/invalid/ProcessAccess_Invalid_2.whiley
@@ -2,5 +2,5 @@ type state is {int y, int x}
 
 type pState is &state
 
-method f(pState this) :
-    this = new {z: 4, x: 3}
+method f(pState _this) :
+    _this = new {z: 4, x: 3}

--- a/tests/invalid/ProcessAccess_Invalid_3.sysout
+++ b/tests/invalid/ProcessAccess_Invalid_3.sysout
@@ -1,3 +1,3 @@
 ../../tests/invalid/ProcessAccess_Invalid_3.whiley:4: invalid assignment expression
-    p.data = this.data
+    p.data = _this.data
     ^^^^^^

--- a/tests/invalid/ProcessAccess_Invalid_3.whiley
+++ b/tests/invalid/ProcessAccess_Invalid_3.whiley
@@ -1,7 +1,7 @@
 type MyProc is &{int data}
 
-method copy(MyProc this, MyProc p):
-    p.data = this.data
+method copy(MyProc _this, MyProc p):
+    p.data = _this.data
 
 method create(int data) -> MyProc:
     return new {data: data}

--- a/tests/invalid/Process_Invalid_1.sysout
+++ b/tests/invalid/Process_Invalid_1.sysout
@@ -1,3 +1,3 @@
 ../../tests/invalid/Process_Invalid_1.whiley:5: invalid assignment expression
-    this.data = d
-    ^^^^^^^^^
+    _this.data = d
+    ^^^^^^^^^^

--- a/tests/invalid/Process_Invalid_1.whiley
+++ b/tests/invalid/Process_Invalid_1.whiley
@@ -1,11 +1,11 @@
 type MyProc1 is &{int data}
 type MyProc2 is &{any data}
 
-method set(MyProc2 this, any d) :
-    this.data = d
+method set(MyProc2 _this, any d) :
+    _this.data = d
 
-method get(MyProc1 this) -> int:
-    return this.data
+method get(MyProc1 _this) -> int:
+    return _this.data
 
 method create(int data) -> MyProc1:
     return new {data: data}

--- a/tests/invalid/Subtype_Invalid_6.whiley
+++ b/tests/invalid/Subtype_Invalid_6.whiley
@@ -1,7 +1,7 @@
 
 type scf6nat is (int n) where n > 0
 
-type scf6tup is ({scf6nat f, int g} this) where this.g > this.f
+type scf6tup is ({scf6nat f, int g} _this) where _this.g > _this.f
 
 function f(scf6tup x) -> int:
     return x.f

--- a/tests/invalid/TupleAssign_Invalid_1.whiley
+++ b/tests/invalid/TupleAssign_Invalid_1.whiley
@@ -1,5 +1,5 @@
 
-type tac1tup is ({int f1, int f2} this) where this.f1 < this.f2
+type tac1tup is ({int f1, int f2} _this) where _this.f1 < _this.f2
 
 method main() :
     tac1tup x = {f1: 1, f2: 3}

--- a/tests/invalid/TupleAssign_Invalid_2.whiley
+++ b/tests/invalid/TupleAssign_Invalid_2.whiley
@@ -1,7 +1,7 @@
 
-type tac2ta is ({int f1, int f2} this) where this.f1 < this.f2
+type tac2ta is ({int f1, int f2} _this) where _this.f1 < _this.f2
 
-type tac2tb is ({int f1, int f2} this) where (this.f1 + 1) < this.f2
+type tac2tb is ({int f1, int f2} _this) where (_this.f1 + 1) < _this.f2
 
 function f(tac2tb y) -> tac2tb:
     return y

--- a/tests/invalid/TupleAssign_Invalid_3.whiley
+++ b/tests/invalid/TupleAssign_Invalid_3.whiley
@@ -1,5 +1,5 @@
 
-type tac3ta is ({int f1, int f2} this) where this.f1 < this.f2
+type tac3ta is ({int f1, int f2} _this) where _this.f1 < _this.f2
 
 method main():
     {int f1, int f2} x = {f1: 2, f2: 3}

--- a/tests/invalid/TupleDefine_Invalid_2.whiley
+++ b/tests/invalid/TupleDefine_Invalid_2.whiley
@@ -1,4 +1,4 @@
-type point is ({int y, int x} this) where (this.x > 0) && (this.y > 0)
+type point is ({int y, int x} _this) where (_this.x > 0) && (_this.y > 0)
 
 function f(point p) -> point:
     return p

--- a/tests/invalid/UnionType_Invalid_7.whiley
+++ b/tests/invalid/UnionType_Invalid_7.whiley
@@ -7,7 +7,7 @@ constant MUL is 3
 
 constant DIV is 4
 
-type bop is ({int op, int rhs, int lhs} this) where ADD <= this.op && this.op <= DIV
+type bop is ({int op, int rhs, int lhs} _this) where ADD <= _this.op && _this.op <= DIV
 
 function f(bop b) -> bop:
     return b

--- a/tests/valid/ConstrainedList_Valid_11.whiley
+++ b/tests/valid/ConstrainedList_Valid_11.whiley
@@ -1,8 +1,8 @@
 type state is ({
     int[] input,
     int pos
-} this)
-where (this.pos >= 0) && (this.pos <= |this.input|)
+} _this)
+where (_this.pos >= 0) && (_this.pos <= |_this.input|)
 
 public function isLetter(int c) -> bool:
     return ('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z')

--- a/tests/valid/FunctionRef_Valid_12.whiley
+++ b/tests/valid/FunctionRef_Valid_12.whiley
@@ -8,7 +8,7 @@ function f(null|SizeGetter x) -> int:
     else:
         return 0
 
-function getSize(Sized this) -> int:
+function getSize(Sized _this) -> int:
     return 1
 
 public export method test():    

--- a/tests/valid/FunctionRef_Valid_13.whiley
+++ b/tests/valid/FunctionRef_Valid_13.whiley
@@ -9,10 +9,10 @@ function f((SizeSetter|SizeGetter) x) -> int:
     else:
         return 0
 
-function getSize(Sized this) -> int:
-    return this.value
+function getSize(Sized _this) -> int:
+    return _this.value
 
-function setSize(Sized this, int value) -> Sized:
+function setSize(Sized _this, int value) -> Sized:
     return { value: value }
 
 public export method test():    

--- a/tests/valid/FunctionRef_Valid_7.whiley
+++ b/tests/valid/FunctionRef_Valid_7.whiley
@@ -2,8 +2,8 @@
 
 type Proc is &{int data}
 
-method read(Proc this, int x) -> int:
-    return x + this->data
+method read(Proc _this, int x) -> int:
+    return x + _this->data
 
 public export method test(Proc p, int arg) -> int:
     return read(p,arg)

--- a/tests/valid/FunctionRef_Valid_9.whiley
+++ b/tests/valid/FunctionRef_Valid_9.whiley
@@ -4,11 +4,11 @@ type Proc is &{
     function func(int) -> int
 }
 
-method func(Proc this, int x) -> int:
+method func(Proc _this, int x) -> int:
     return x + 1
 
-public export method test(Proc this, int arg) -> int:
-    return (*this).func(arg)
+public export method test(Proc _this, int arg) -> int:
+    return (*_this).func(arg)
 
 function id(int x) -> int:
     return x

--- a/tests/valid/Lambda_Valid_3.whiley
+++ b/tests/valid/Lambda_Valid_3.whiley
@@ -54,8 +54,8 @@ requires amount >= 0:
 
 // Construct buffer from list of bytes
 public method BufferInputStream(byte[] buffer) -> InputStream:
-    BufferState this = new {bytes: buffer, pos: 0}
-    return {read: &(int x -> read(this, x))}
+    BufferState _this = new {bytes: buffer, pos: 0}
+    return {read: &(int x -> read(_this, x))}
 
 public export method test() :
     InputStream bis = BufferInputStream(toBytes("hello"))

--- a/tests/valid/Lambda_Valid_4.whiley
+++ b/tests/valid/Lambda_Valid_4.whiley
@@ -59,10 +59,10 @@ method eof(BufferState state) -> bool:
 
 // Construct buffer from list of bytes
 public method BufferInputStream(byte[] buffer) -> InputStream:
-    BufferState this = new {bytes: buffer, pos: 0}
+    BufferState _this = new {bytes: buffer, pos: 0}
     return {
-        read: &(int x -> read(this, x)),
-        eof: &( -> eof(this))
+        read: &(int x -> read(_this, x)),
+        eof: &( -> eof(_this))
     }
 
 method read(string s) -> byte[]:

--- a/tests/valid/Lifetime_Lambda_Valid_1.whiley
+++ b/tests/valid/Lifetime_Lambda_Valid_1.whiley
@@ -1,0 +1,5 @@
+type meth is method<a, b>(&a:int, &b:int)->(&a:int)
+
+public export method test():
+    meth m = &<a, b>(&a:int x, &b:int y -> a:new 1)
+    m = &<a, b>(&a:int x, &b:int y -> new 1)

--- a/tests/valid/Lifetime_Lambda_Valid_2.whiley
+++ b/tests/valid/Lifetime_Lambda_Valid_2.whiley
@@ -1,0 +1,9 @@
+// Test that lifetime parameters are replaced without capturing nested parameters in return types
+
+type meth1 is method<a,b>(&a:int, &b:int)->(&b:meth2)
+type meth2 is method<a,b>(&a:int, &b:int)->(int)
+
+public export method test():
+    meth2 m2 = &<aa, bb>(&aa:int x, &bb:int y -> *(new 1))
+    meth1 m1 = &<bb, aa>(&bb:int x, &aa:int y -> aa:new m2)
+    &*:meth2 m3 = m1<this, *>(this:new 2, new 3)

--- a/tests/valid/Lifetime_Lambda_Valid_3.whiley
+++ b/tests/valid/Lifetime_Lambda_Valid_3.whiley
@@ -1,0 +1,12 @@
+// Test that variable declarations are parsed correctly
+// (tricky because of headless statements and definite types)
+
+type myint is int
+
+public export method test():
+    method()->(&myint) m = &(-> new 1)
+    &myint a = m()
+    &*:myint b = m()
+    &this:myint c = m()
+    myblock:
+        &myblock:myint d = m()

--- a/tests/valid/Lifetime_Lambda_Valid_4.whiley
+++ b/tests/valid/Lifetime_Lambda_Valid_4.whiley
@@ -1,0 +1,16 @@
+// Test recursive types
+
+type mymethod is method<a>(&*:mymethod)->(&a:mymethod)
+
+method <a> m (&*:mymethod x) -> &a:mymethod:
+    return a:new &m
+
+public export method test():
+    &mymethod x = m<*>(new &m)
+    mymethod xx = &<a>(&mymethod y -> *(new y))
+    xx = &<b>(&mymethod y -> *(new y))
+    &this:mymethod y = m<this>(new &m)
+    mymethod yy = &<a>(&mymethod z -> *(new z))
+    yy = &<b>(&mymethod z -> *(new z))
+    a:
+        &a:mymethod z = m<a>(new &m)

--- a/tests/valid/Lifetime_Lambda_Valid_5.whiley
+++ b/tests/valid/Lifetime_Lambda_Valid_5.whiley
@@ -1,0 +1,6 @@
+// Test contra-variant parameter types
+
+public export method test():
+    method<a>(&a:int, &int)->(&int) m1 = &<b>(&b:int x, &b:int y -> new 1)
+    method<a>(&a:int, &int)->(&int) m2 = &<b>(&b:int x, &b:int y -> new 1)
+    method<a, b>(&a:int, &b:int)->(&a:int) m3 = &<b, a>(&b:int x, &a:int y -> b:new 1)

--- a/tests/valid/Lifetime_Lambda_Valid_6.whiley
+++ b/tests/valid/Lifetime_Lambda_Valid_6.whiley
@@ -1,0 +1,11 @@
+// Test co-variant return types
+
+public export method test():
+    method<a>(&a:int)->(&a:int) m1 = &<b>(&b:int x -> new 1)
+    &int xx = m1(new 2)
+    assume (*xx) == 1
+    method<a, b>(&a:int)->(&a:int|&b:bool) m2 = &<b, c>(&b:int x -> c:new true)
+    c:
+        d:
+            &this:bool yy = m2<c, *>(c:new 1)
+            assume (*yy) == true

--- a/tests/valid/Lifetime_Lambda_Valid_7.whiley
+++ b/tests/valid/Lifetime_Lambda_Valid_7.whiley
@@ -1,0 +1,26 @@
+// Test context lifetimes
+
+public export method test():
+    &this:int x = this:new 2
+    function()->(&this:int) m1 = &(->x)
+    int i = *m1()
+    assume i == 2
+
+    method[this]()->(int) m2 = &[this](->*x)
+    i = m2()
+    assume i == 2
+    *x = 3
+    i = m2()
+    assume i == 3
+
+    a:
+        &a:int y = a:new 4
+        method[this,a]()->(int) m3 = &[this](->*x)
+        i = m3()
+        assume i == 3
+        m3 = &[this,a](->*x)
+        i = m3()
+        assume i == 3
+        method[this,a]()->(int) m4 = &[this,a](->*y)
+        i = m4()
+        assume i == 4

--- a/tests/valid/Lifetime_Valid_1.whiley
+++ b/tests/valid/Lifetime_Valid_1.whiley
@@ -1,0 +1,45 @@
+// test different lifetimes without subtyping
+
+public export method test():
+    &int ptr1 = new 1
+    assume (*ptr1) == 1
+
+    &*:int ptr2 = new 2
+    assume (*ptr2) == 2
+
+    &int ptr3 = *:new 3
+    assume (*ptr3) == 3
+
+    &this:int ptr4 = this:new 4
+    assume (*ptr4) == 4
+
+    myblock:
+        &myblock:int ptr5 = myblock:new 5
+        assume (*ptr5) == 5
+
+        mynestedblock:
+            &mynestedblock:int ptr6 = mynestedblock:new 6
+            assume (*ptr6) == 6
+
+            &myblock:int ptr7 = myblock:new 7
+            assume (*ptr7) == 7
+
+            &int ptr8 = *:new 8
+            assume (*ptr8) == 8
+
+            &this:int ptr9 = this:new 9
+            assume (*ptr9) == 9
+
+        &myblock:int ptr10 = myblock:new 10
+        assume (*ptr10) == 10
+
+    &*:int ptr11 = *:new 11
+    assume (*ptr11) == 11
+
+    // name should be available again
+    mynestedblock:
+        &mynestedblock:int ptr12 = mynestedblock:new 12
+        assume (*ptr12) == 12
+
+    &this:int ptr13 = this:new 13
+    assume (*ptr13) == 13

--- a/tests/valid/Lifetime_Valid_10.whiley
+++ b/tests/valid/Lifetime_Valid_10.whiley
@@ -1,0 +1,12 @@
+// test that substitution does not accidentaly substitute already substituted values
+
+method <a, b> m(&a:int x, &b:int y) -> &a:int:
+    return x
+
+public export method test():
+    a:
+        b:
+            &a:int x = a:new 1
+            &b:int y = b:new 2
+            &a:int z = m(x, y)
+            assume x == z

--- a/tests/valid/Lifetime_Valid_2.whiley
+++ b/tests/valid/Lifetime_Valid_2.whiley
@@ -1,0 +1,22 @@
+// test subtyping (outlives) with different lifetimes
+
+public export method test():
+    &this:int ptr1 = *:new 1
+    assume (*ptr1) == 1
+
+    myblock:
+        &myblock:int ptr2 = this:new 2
+        assume (*ptr2) == 2
+
+        &myblock:int ptr3 = *:new 3
+        assume (*ptr3) == 3
+
+        mynestedblock:
+            &mynestedblock:int ptr4 = myblock:new 4
+            assume (*ptr4) == 4
+
+            &mynestedblock:int ptr5 = this:new 5
+            assume (*ptr5) == 5
+
+            &mynestedblock:int ptr6 = *:new 6
+            assume (*ptr6) == 6

--- a/tests/valid/Lifetime_Valid_3.whiley
+++ b/tests/valid/Lifetime_Valid_3.whiley
@@ -1,0 +1,61 @@
+// test subtyping (outlives) combined with lifetime parameters
+
+method <a, b> m(&a:int x, &b:int y, &*:int z):
+    &a:int ptr1 = x
+    ptr1 = a:new 1
+    assume (*ptr1) == 1
+
+    &b:int ptr2 = y
+    ptr2 = b:new 2
+    assume (*ptr2) == 2
+
+    &a:int ptr3 = *:new 3
+    assume (*ptr3) == 3
+
+    &b:int ptr4 = *:new 4
+    assume (*ptr4) == 4
+
+    &this:int ptr5 = a:new 5
+    assume (*ptr5) == 5
+    ptr5 = x
+    ptr5 = y
+
+    &this:int ptr6 = b:new 6
+    assume (*ptr6) == 6
+    ptr6 = y
+    ptr6 = x
+
+public export method test():
+    &this:int ptr1 = this:new 1
+    assume (*ptr1) == 1
+
+    m(ptr1, ptr1, new 99)
+
+    myblock:
+        &myblock:int ptr2 = myblock:new 2
+        assume (*ptr2) == 2
+
+        m(ptr1, ptr2, new 99)
+        m(ptr2, ptr1, new 99)
+        m(ptr2, ptr2, new 99)
+
+        &myblock:int ptr3 = *:new 3
+        assume (*ptr3) == 3
+
+        m(ptr1, ptr3, new 99)
+        m(ptr2, ptr3, new 99)
+        m(ptr3, ptr1, new 99)
+        m(ptr3, ptr2, new 99)
+        m(ptr3, ptr3, new 99)
+
+        mynestedblock:
+            &mynestedblock:int ptr4 = mynestedblock:new 4
+            assume (*ptr4) == 4
+
+            m(ptr1, ptr4, new 99)
+            m(ptr2, ptr4, new 99)
+            m(ptr3, ptr4, new 99)
+            m(ptr4, ptr1, new 99)
+            m(ptr4, ptr2, new 99)
+            m(ptr4, ptr3, new 99)
+            m(ptr4, ptr4, new 99)

--- a/tests/valid/Lifetime_Valid_4.whiley
+++ b/tests/valid/Lifetime_Valid_4.whiley
@@ -1,0 +1,19 @@
+// test subtyping (outlives) for method parameters and return types
+
+method <a> m(&a:int x, &a:int y) -> &*:int:
+    return new 3
+
+public export method test():
+    &this:int ptr1 = this:new 1
+    &*:int ptr2 = *:new 2
+
+    &this:int ptr3 = m(ptr1, ptr1)
+    assume (*ptr3) == 3
+    ptr3 = m<*>(ptr2, ptr2)
+    assume (*ptr3) == 3
+    ptr3 = m<this>(ptr2, ptr2)
+    assume (*ptr3) == 3
+    ptr3 = m(ptr1, ptr2)
+    assume (*ptr3) == 3
+    ptr3 = m(ptr2, ptr1)
+    assume (*ptr3) == 3

--- a/tests/valid/Lifetime_Valid_5.whiley
+++ b/tests/valid/Lifetime_Valid_5.whiley
@@ -1,0 +1,34 @@
+// test lifetime substitution for method calls
+
+method <a, b> m1(&a:int x, &b:int y) -> &a:int:
+    *x = (*x)+1
+    &a:int result = a:new (*y)
+    return result
+
+method <a, b> m2(&a:int x, &b:int y) -> &b:int:
+    *y = (*y)+1
+    &b:int result = *:new (*x)
+    return result
+
+public export method test():
+    test:
+        &this:int ptr1 = this:new 1
+        &test:int ptr2 = test:new 2
+
+        &this:int ptr3 = m1<this, test>(ptr1, ptr2)
+        assume (*ptr1) == 2
+        assume (*ptr2) == 2
+        assume (*ptr3) == 2
+
+        &test:int ptr4 = m2<this, test>(ptr1, ptr2)
+        assume (*ptr1) == 2
+        assume (*ptr2) == 3
+        assume (*ptr3) == 2
+        assume (*ptr4) == 2
+
+        &test:int ptr5 = m1<test, test>(ptr2, ptr2)
+        assume (*ptr1) == 2
+        assume (*ptr2) == 4
+        assume (*ptr3) == 2
+        assume (*ptr4) == 2
+        assume (*ptr5) == 4

--- a/tests/valid/Lifetime_Valid_6.whiley
+++ b/tests/valid/Lifetime_Valid_6.whiley
@@ -1,0 +1,33 @@
+// test lifetime inference without overloading
+
+method <a, b> m1(&a:int x, &a:int y, &b:int z) -> &a:int:
+    return new 3
+
+method <a, b> m2(&a:int x, &b:int y, &b:int z) -> &b:int:
+    return new 4
+
+public export method test():
+    test:
+        &this:int ptr1 = this:new 1
+        &test:int ptr2 = test:new 2
+        &*:int ptr3 = *:new 2
+
+        // <test, *>
+        &test:int ptr4 = m1(ptr1, ptr2, ptr3)
+
+        // <this, test>
+        &this:int ptr5 = m1(ptr1, ptr3, ptr2)
+
+        // <*, this>
+        &*:int ptr6 = m1(ptr3, ptr3, ptr1)
+
+        // --
+
+        // <this, test>
+        &test:int ptr7 = m2(ptr1, ptr2, ptr3)
+
+        // <test, this>
+        &this:int ptr8 = m2(ptr1, ptr3, ptr1)
+
+        // <this, *>
+        &*:int ptr9 = m2(ptr1, ptr3, ptr3)

--- a/tests/valid/Lifetime_Valid_7.whiley
+++ b/tests/valid/Lifetime_Valid_7.whiley
@@ -1,0 +1,45 @@
+// test lifetime inference with lifetime overloading but same types
+
+method <a> m(&a:int x, &a:int y) -> int:
+    return 1
+
+method <a> m(&a:int x, &*:int y) -> int:
+    return 2
+
+method <a> m(&*:int x, &a:int y) -> int:
+    return 3
+
+method <a> m2(&a:int x, &a:int y) -> int:
+    return 4
+
+method <a, b> m2(&a:int x, &b:int y) -> int:
+    return 5
+
+public export method test():
+    test:
+        &this:int ptr1 = this:new 1
+        &test:int ptr2 = test:new 2
+        &*:int ptr3 = *:new 2
+
+        // variant1: (&test:int, &test:int) <--
+        // variant2: no
+        // variant3: no
+        int r = m(ptr1, ptr2)
+        assume r == 1
+
+        // variant1: (&this:int, &this:int)
+        // variant2: no
+        // variant3: (&*:int, &this:int) <--
+        r = m(ptr3, ptr1)
+        assume r == 3
+
+        // variant1: (&test:int, &test:int)
+        // variant2: (&test:int, &*:int) <--
+        // variant3: no
+        r = m(ptr2, ptr3)
+        assume r == 2
+
+        // variant4: (&test:int, &test:int)
+        // variant5: (&test:int, &this:int) <--
+        r = m2(ptr2, ptr3)
+        assume r == 5

--- a/tests/valid/Lifetime_Valid_8.whiley
+++ b/tests/valid/Lifetime_Valid_8.whiley
@@ -1,0 +1,28 @@
+// test lifetime inference with lifetime overloading and different types
+
+method <a, b> m((&a:int)|(&b:bool) x, &a:int y, bool z) -> &b:int:
+    return b:new 1
+
+method <a> m(&a:bool x, &a:int y, bool z) -> &a:int:
+    return a:new 2
+
+method <a> m(&*:int x, &a:int y, int|bool z) -> &a:int:
+    return a:new 3
+
+method <a> m(&*:int x, &a:int y, bool z) -> &a:int:
+    return a:new 4
+
+public export method test():
+    // variant1: <this, *> ((&this:int)|(&*:bool), &this:int, bool z)
+    // variant2: no
+    // variant3: no
+    // variant4: no
+    &*:int p1 = m(this:new 1, this:new 2, true)
+    assume (*p1) == 1
+
+    // variant1: <this, *> ((&this:int)|(&*:bool), &this:int, bool z)
+    // variant2: no
+    // variant3: <this> (&*:int, &this:int, int|bool)
+    // variant4: <this> (&*:int, &this:int, bool) <--
+    &this:int p2 = m(*:new 1, this:new 2, true)
+    assume (*p2) == 4

--- a/tests/valid/Lifetime_Valid_9.whiley
+++ b/tests/valid/Lifetime_Valid_9.whiley
@@ -1,0 +1,14 @@
+// use lifetime arguments to disambiguate (see also Lifetime_Invalid_8)
+
+method <a, b> m((&a:int)|(&b:bool) x, (&a:int)|(&b:int) y) -> &a:int:
+    return a:new 1
+
+public export method test():
+    // <this, *> --> ((&this:int)|(&*:bool), &this:int)
+    // <*, this> --> ((&*:int)|(&this:bool), &this:int)
+    (&*:int)|(&*:bool) x = *:new 1
+    &this:int y = this:new 1
+
+    &this:int p1 = m<this, *>(x, y)
+    &*:int p2 = m<*, this>(x, y)
+    &this:int p3 = m<this, this>(x, y)

--- a/tests/valid/MessageRef_Valid_1.whiley
+++ b/tests/valid/MessageRef_Valid_1.whiley
@@ -4,7 +4,7 @@ type MyProc is &{int position}
 
 type MyMeth is method(MyProc, int) -> int
 
-method read(MyProc this, int x) -> int:
+method read(MyProc _this, int x) -> int:
     return x + 123
 
 public export method test(MyMeth m, MyProc proc) -> int:

--- a/tests/valid/MessageRef_Valid_2.whiley
+++ b/tests/valid/MessageRef_Valid_2.whiley
@@ -7,8 +7,8 @@ type Reader is {
     method read(FileReader, int) -> int
 }
 
-method read(FileReader this, int amount) -> int:
-    int r = amount + this->position
+method read(FileReader _this, int amount) -> int:
+    int r = amount + _this->position
     return r
 
 method openReader() -> Reader:

--- a/tests/valid/MessageSend_Valid_1.whiley
+++ b/tests/valid/MessageSend_Valid_1.whiley
@@ -2,7 +2,7 @@
 
 type MyObject is &{int field}
 
-method f(MyObject this, int x) :
+method f(MyObject _this, int x) :
     assume x == 1
 
 public export method test() :

--- a/tests/valid/MessageSend_Valid_2.whiley
+++ b/tests/valid/MessageSend_Valid_2.whiley
@@ -2,8 +2,8 @@
 
 type Proc is &{int state}
 
-method get(Proc this) -> int:
-    return this->state
+method get(Proc _this) -> int:
+    return _this->state
 
 method f(Proc x) -> int:
     return get(x)

--- a/tests/valid/MessageSend_Valid_3.whiley
+++ b/tests/valid/MessageSend_Valid_3.whiley
@@ -2,8 +2,8 @@
 
 type Proc is &{int state}
 
-method get(Proc this) -> int:
-    return this->state
+method get(Proc _this) -> int:
+    return _this->state
 
 method f(Proc x) -> int[]:
     return [1, 2, 3, get(x)]

--- a/tests/valid/MessageSend_Valid_4.whiley
+++ b/tests/valid/MessageSend_Valid_4.whiley
@@ -4,8 +4,8 @@ type wmcr6tup is {int y, int x}
 
 type Proc is &{int state}
 
-method get(Proc this) -> int:
-    return this->state
+method get(Proc _this) -> int:
+    return _this->state
 
 method f(Proc x, int y) -> wmcr6tup:
     return {y: get(x), x: y}

--- a/tests/valid/MessageSend_Valid_5.whiley
+++ b/tests/valid/MessageSend_Valid_5.whiley
@@ -2,17 +2,17 @@
 
 type Sum is &{int result, int[] items}
 
-method start(Sum this) :
+method start(Sum _this) :
     int sum = 0
     int i = 0
-    int[] items = this->items
+    int[] items = _this->items
     while i < |items| where i >= 0:
         sum = sum + items[i]
         i = i + 1
-    this->result = sum
+    _this->result = sum
 
-method get(Sum this) -> int:
-    return this->result
+method get(Sum _this) -> int:
+    return _this->result
 
 method create(int[] items) -> Sum:
     return new {result: 0, items: items}

--- a/tests/valid/MethodCall_Valid_4.whiley
+++ b/tests/valid/MethodCall_Valid_4.whiley
@@ -1,16 +1,16 @@
 type Sum is &{int result, int[] items}
 
-method start(Sum this) :
+method start(Sum _this) :
     int sum = 0
     int i = 0
-    int[] items = this->items
+    int[] items = _this->items
     while i < |items| where i >= 0:
         sum = sum + items[i]
         i = i + 1
-    this->result = sum
+    _this->result = sum
 
-method get(Sum this) -> int:
-    return this->result
+method get(Sum _this) -> int:
+    return _this->result
 
 method create(int[] items) -> Sum:
     return new {result: 0, items: items}

--- a/tests/valid/ProcessAccess_Valid_1.whiley
+++ b/tests/valid/ProcessAccess_Valid_1.whiley
@@ -1,10 +1,10 @@
 type etype is {int rest, int mode}
 type Ptype is &etype
 
-method get(Ptype this) -> int:
-    this->mode = 1
-    this->rest = 123
-    return this->mode
+method get(Ptype _this) -> int:
+    _this->mode = 1
+    _this->rest = 123
+    return _this->mode
 
 public export method test() :
     Ptype p = new {rest: 2, mode: 2}

--- a/tests/valid/ProcessAccess_Valid_2.whiley
+++ b/tests/valid/ProcessAccess_Valid_2.whiley
@@ -2,9 +2,9 @@ type state is {int y, int x}
 
 type pState is &state
 
-method send(pState this, int z) :
-    assume this->x == 1
-    assume this->y == 2
+method send(pState _this, int z) :
+    assume _this->x == 1
+    assume _this->y == 2
     assume z == 1
 
 public export method test() :

--- a/tests/valid/Process_Valid_1.whiley
+++ b/tests/valid/Process_Valid_1.whiley
@@ -4,10 +4,10 @@ type state is {int y, int x}
 
 type pState is &state
 
-method send(pState this, int x) :
-    this->x = x
-    assert this->x == x
-    assume (*this) == {x: 3, y: 2}
+method send(pState _this, int x) :
+    _this->x = x
+    assert _this->x == x
+    assume (*_this) == {x: 3, y: 2}
 
 public export method test() :
     pState ps = new {y: 2, x: 1}

--- a/tests/valid/Process_Valid_10.whiley
+++ b/tests/valid/Process_Valid_10.whiley
@@ -2,16 +2,16 @@
 
 type Queue is {int[] items, int length}
 
-method get(&Queue this) -> int:
-    this->length = this->length - 1
-    return this->items[this->length]
+method get(&Queue _this) -> int:
+    _this->length = _this->length - 1
+    return _this->items[_this->length]
 
-method put(&Queue this, int item) :
-    this->items[this->length] = item
-    this->length = this->length + 1
+method put(&Queue _this, int item) :
+    _this->items[_this->length] = item
+    _this->length = _this->length + 1
 
-method isEmpty(&Queue this) -> bool:
-    return this->length == 0
+method isEmpty(&Queue _this) -> bool:
+    return _this->length == 0
 
 public export method test() :
     int[] items = [1, 2, 3, 4, 5]

--- a/tests/valid/Process_Valid_11.whiley
+++ b/tests/valid/Process_Valid_11.whiley
@@ -4,8 +4,8 @@ type state is ({int y, int x} s) where s.x < s.y
 
 type pState is &state
 
-method send2(pState this, int x) -> int:
-    return this->x + this->y
+method send2(pState _this, int x) -> int:
+    return _this->x + _this->y
 
 public export method test() :
     int x = send2(new {y: 2, x: 1},1)

--- a/tests/valid/Process_Valid_12.whiley
+++ b/tests/valid/Process_Valid_12.whiley
@@ -4,8 +4,8 @@ type state is {int y, int x}
 
 type pState is &state
 
-method send2(pState this, int x) -> int:
-    return this->x + this->y
+method send2(pState _this, int x) -> int:
+    return _this->x + _this->y
 
 public export method test() :
     int x = send2(new {y: 2, x: 1},1)

--- a/tests/valid/Process_Valid_4.whiley
+++ b/tests/valid/Process_Valid_4.whiley
@@ -2,8 +2,8 @@
 
 type MyProc is &{int x}
 
-method inc(MyProc this, int i) :
-    this->x = this->x + i
+method inc(MyProc _this, int i) :
+    _this->x = _this->x + i
 
 public export method test() :
     MyProc mproc = new {x: 1}

--- a/tests/valid/Process_Valid_5.whiley
+++ b/tests/valid/Process_Valid_5.whiley
@@ -2,8 +2,8 @@
 
 type MyProc is &{bool flag}
 
-method run(MyProc this) -> bool:
-    if this->flag:
+method run(MyProc _this) -> bool:
+    if _this->flag:
         return true
     else:
         return false

--- a/tests/valid/Process_Valid_6.whiley
+++ b/tests/valid/Process_Valid_6.whiley
@@ -1,7 +1,7 @@
 type Actor is {int data}
 
-method get(&Actor this) -> int:
-    return this->data
+method get(&Actor _this) -> int:
+    return _this->data
 
 method createActor(int n) -> &Actor:
     return new {data: n}

--- a/tests/valid/Process_Valid_7.whiley
+++ b/tests/valid/Process_Valid_7.whiley
@@ -2,11 +2,11 @@
 
 type MyProc2 is &{any data}
 
-method set(MyProc2 this, int d) :
-    this->data = (any)d
+method set(MyProc2 _this, int d) :
+    _this->data = (any)d
 
-method get(MyProc2 this) -> any:
-    return this->data
+method get(MyProc2 _this) -> any:
+    return _this->data
 
 method create(any data) -> MyProc2:
     return new {data: data}

--- a/tests/valid/Process_Valid_8.whiley
+++ b/tests/valid/Process_Valid_8.whiley
@@ -2,11 +2,11 @@
 
 type MyProc2 is {any data}
 
-method set(&MyProc2 this, int d) :
-    this->data = (any)d
+method set(&MyProc2 _this, int d) :
+    _this->data = (any)d
 
-method get(&MyProc2 this) -> any:
-    return this->data
+method get(&MyProc2 _this) -> any:
+    return _this->data
 
 method create(any data) -> &MyProc2:
     return new {data: data}

--- a/tests/valid/Process_Valid_9.whiley
+++ b/tests/valid/Process_Valid_9.whiley
@@ -1,15 +1,15 @@
 type Queue is {int[] items, int length}
 
-method get(&Queue this) -> int:
-    this->length = this->length - 1
-    return this->items[this->length]
+method get(&Queue _this) -> int:
+    _this->length = _this->length - 1
+    return _this->items[_this->length]
 
-method put(&Queue this, int item) :
-    this->items[this->length] = item
-    this->length = this->length + 1
+method put(&Queue _this, int item) :
+    _this->items[_this->length] = item
+    _this->length = _this->length + 1
 
-method isEmpty(&Queue this) -> bool:
-    return this->length == 0
+method isEmpty(&Queue _this) -> bool:
+    return _this->length == 0
 
 method Queue(int capacity) -> &Queue:
     int[] slots = [0; capacity]

--- a/tests/valid/RecordAccess_Valid_1.whiley
+++ b/tests/valid/RecordAccess_Valid_1.whiley
@@ -4,9 +4,9 @@ type etype is {int mode, ...}
 
 type Ptype is &etype
 
-method get(Ptype this) -> int:
-    this->mode = 1
-    return this->mode
+method get(Ptype _this) -> int:
+    _this->mode = 1
+    return _this->mode
 
 public export method test() :
     assume get(new (etype) {mode:2}) == 1

--- a/tests/valid/RecordAssign_Valid_1.whiley
+++ b/tests/valid/RecordAssign_Valid_1.whiley
@@ -1,6 +1,6 @@
 
 
-type tac1tup is ({int f1, int f2} this) where this.f1 < this.f2
+type tac1tup is ({int f1, int f2} _this) where _this.f1 < _this.f2
 
 function f() -> tac1tup:
     return {f1: 2, f2: 3}

--- a/tests/valid/RecordAssign_Valid_4.whiley
+++ b/tests/valid/RecordAssign_Valid_4.whiley
@@ -1,8 +1,8 @@
 
 
-type tac2ta is ({int f1, int f2} this) where this.f1 < this.f2
+type tac2ta is ({int f1, int f2} _this) where _this.f1 < _this.f2
 
-type tac2tb is ({int f1, int f2} this) where (this.f1 + 1) < this.f2
+type tac2tb is ({int f1, int f2} _this) where (_this.f1 + 1) < _this.f2
 
 function f(tac2ta x) -> tac2tb:
     return {f1: x.f1 - 1, f2: x.f2}

--- a/tests/valid/RecursiveType_Valid_11.whiley
+++ b/tests/valid/RecursiveType_Valid_11.whiley
@@ -5,8 +5,8 @@ constant SUB is 2
 constant MUL is 3
 constant DIV is 4
 
-type binop is ({int op, expr left, expr right} this)
-where this.op == ADD || this.op ==  SUB || this.op ==  MUL || this.op ==  DIV
+type binop is ({int op, expr left, expr right} _this)
+where _this.op == ADD || _this.op ==  SUB || _this.op ==  MUL || _this.op ==  DIV
 
 type expr is int | binop
 

--- a/tests/valid/RecursiveType_Valid_12.whiley
+++ b/tests/valid/RecursiveType_Valid_12.whiley
@@ -2,8 +2,8 @@
 
 type Tree is null | Node
 
-type Node is ({int data, Tree rhs, Tree lhs} this)
-where ((this.lhs == null) || (this.lhs.data < this.data)) && ((this.rhs == null) || (this.rhs.data > this.data))
+type Node is ({int data, Tree rhs, Tree lhs} _this)
+where ((_this.lhs == null) || (_this.lhs.data < _this.data)) && ((_this.rhs == null) || (_this.rhs.data > _this.data))
 
 function Tree(int data, Tree left, Tree right) -> Tree
 requires ((left == null) || (left.data < data)) && ((right == null) || (right.data > data)):

--- a/tests/valid/RecursiveType_Valid_14.whiley
+++ b/tests/valid/RecursiveType_Valid_14.whiley
@@ -8,9 +8,9 @@ constant MUL is 3
 
 constant DIV is 4
 
-type binop is ({int op, Expr left, Expr right} this) where this.op == ADD || this.op ==  SUB || this.op ==  MUL || this.op ==  DIV
+type binop is ({int op, Expr left, Expr right} _this) where _this.op == ADD || _this.op ==  SUB || _this.op ==  MUL || _this.op ==  DIV
 
-type asbinop is ({int op, Expr left, Expr right} this) where this.op == ADD || this.op ==  SUB
+type asbinop is ({int op, Expr left, Expr right} _this) where _this.op == ADD || _this.op ==  SUB
 
 type Expr is int | binop
 

--- a/tests/valid/RecursiveType_Valid_22.whiley
+++ b/tests/valid/RecursiveType_Valid_22.whiley
@@ -2,8 +2,8 @@
 
 type SortedList is null | SortedListNode
 
-type SortedListNode is ({SortedList next, int data} this)
-where (this.next == null) || (this.data < this.next.data)
+type SortedListNode is ({SortedList next, int data} _this)
+where (_this.next == null) || (_this.data < _this.next.data)
 
 function SortedList(int head, SortedList tail) -> SortedList
 requires (tail == null) || (head < tail.data):

--- a/tests/valid/UnionType_Valid_18.whiley
+++ b/tests/valid/UnionType_Valid_18.whiley
@@ -4,7 +4,7 @@ type utr12nat is (int x) where x >= 0
 
 type intList is utr12nat | int[]
 
-type tupper is ({int op, intList il} this) where (this.op >= 0) && (this.op <= 5)
+type tupper is ({int op, intList il} _this) where (_this.op >= 0) && (_this.op <= 5)
 
 function f(tupper y) -> (int result)
 ensures result >= 0:


### PR DESCRIPTION
This pull request introduces a concept of lifetimes into Whiley.

A lifetime describes a region in the source code.
Possible regions are method bodies and named blocks.
Each lifetime has a name. The lifetime for method bodies is named `this`.
The lifetime of named blocks have the block’s name.
Furthermore, the special lifetime `*` describes the region covering the whole program.

Each reference type is annotated with a lifetime.
It states when the memory pointed to by that reference should be alive, i.e. not yet freed.

Affected parts of the compiler are:
* lexer and parser
   * new keyword `this`
   * backwards-compatible syntax extension for references, new expressions, method declarations, method invocation, and lambda expressions
* type system
   * reference types now carry a lifetime
   * method types now carry lifetime parameters and context lifetimes
* lambda expressions
   * introduce lifetime parameters as for any other normal method
   * introduce a concept of context lifetimes
* flow typing
   * keep track of how lifetimes relate to each other
   * check that dereferenced lifetimes in lambda expressions are declared as context lifetimes
* method invocation
   * infer suitable lifetime arguments
   * substitute lifetime parameters in parameter types with inferred or explicitly specified lifetime arguments before checking  whether the arguments are subtypes of parameters
   * apply the substitution also to the method's return type
* subtyping / type intersection
   * for references: subtype's lifetime must outlive the supertype's lifetime
   * for methods:
      * apply a proper substitution of lifetime parameters
      * compare context lifetimes