### PR TITLE
Add invariant to sorted property.

### DIFF
--- a/tests/valid/DoWhile_Valid_9.whiley
+++ b/tests/valid/DoWhile_Valid_9.whiley
@@ -1,7 +1,7 @@
 type pos is (int x) where x >= 1
 
 property sorted(int[] arr, int n)
-where all { i in 1..n | arr[i-1] <= arr[i] }
+where |arr| == 0 || (1 <= n && n <= |arr| && all { i in 1..n | arr[i-1] <= arr[i] })
 
 function bubbleSort(int[] items) -> (int[] result)
 // Resulting array is sorted


### PR DESCRIPTION
This ensures that empty arrays will verify and that
the length used in the universal quantifier is within
the length of the array.

Closes #857 